### PR TITLE
[fix](layout) hide task from menu when tasks is empty

### DIFF
--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -51,12 +51,16 @@
         <% end %>
       </li>
 
-      <li class="nav-item">
-        <%= link to: Kaffy.Utils.router().kaffy_task_path(@conn, :index), class: "nav-link" do %>
-            <i class="fas fa-fw fa-tasks"></i>
-            <span>Tasks</span>
-        <% end %>
-      </li>
+      <% tasks = Kaffy.ResourceAdmin.tasks_info() %>
+
+      <%= if not Enum.empty?(tasks) do %>
+        <li class="nav-item">
+          <%= link to: Kaffy.Utils.router().kaffy_task_path(@conn, :index), class: "nav-link" do %>
+              <i class="fas fa-fw fa-tasks"></i>
+              <span>Tasks</span>
+          <% end %>
+        </li>
+      <% end %>
 
       <!-- Divider -->
       <hr class="sidebar-divider">


### PR DESCRIPTION
I have the feeling that it's best to keep the menu bar as clean as possible, and so not display option that aren't used.
Not everybody is going to use the scheduled task, so maybe best to keep them away from our eyes :)


