### PR TITLE
[fix](layout) esthetic changes on the index page

### DIFF
--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -20,6 +20,9 @@
 
   <link href="/kaffy/vendor/datatables/dataTables.bootstrap4.min.css" rel="stylesheet">
 
+  <!-- Custom Kaffy styles-->
+  <link href="/kaffy/css/kaffy.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">

--- a/lib/kaffy_web/templates/resource/_list_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_list_table.html.eex
@@ -1,4 +1,4 @@
-<thead>
+<thead class="thead-dark">
     <tr>
         <%= for field <- @fields do %>
             <th><%= Kaffy.ResourceSchema.kaffy_field_name(@my_resource[:schema], field) %></th>
@@ -25,14 +25,6 @@
         </tr>
     <% end %>
 </thead>
-
-<tfoot>
-    <tr>
-        <%= for field <- @fields do %>
-            <th><%= Kaffy.ResourceSchema.kaffy_field_name(@my_resource[:schema], field) %></th>
-        <% end %>
-    </tr>
-</tfoot>
 
 <tbody>
 </tbody>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -29,7 +29,7 @@
   <div class="card-body">
     <div>
       <div id="column-names" style="display:none;"><%= Kaffy.ResourceSchema.display_string_fields(@fields, []) %></div>
-      <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+      <table class="table table-striped" id="dataTable" width="100%" cellspacing="0">
         <%= render KaffyWeb.ResourceView, "_list_table.html", conn: @conn, fields: @fields, context: @context, resource: @resource, my_resource: @my_resource %>
       </table>
     </div>

--- a/priv/static/css/kaffy.css
+++ b/priv/static/css/kaffy.css
@@ -1,0 +1,23 @@
+/*!
+ * custom Kaffy Css
+ */
+
+
+.table .thead-dark th {
+    color: #fff;
+    background-color: #4e73df;
+    border-color: #4f64a1;
+}
+
+.table-striped tbody tr:nth-of-type(2n+1) {
+    background-color: rgba(0,0,0,.02);
+}
+
+.index-table-footer {
+    margin-top: 20px;
+}
+
+#dataTable_length {
+    padding-top: 0.35em;
+    white-space: nowrap;
+}

--- a/priv/static/js/demo/datatables-demo.js
+++ b/priv/static/js/demo/datatables-demo.js
@@ -16,6 +16,7 @@ $(document).ready(function () {
     "columns": tableColumnNames,
     "scrollX": true,
     "ajax": api_url,
+    "dom": '<f<t><"row index-table-footer" <"col-sm-12 col-md-5" i> <"col-sm-12 col-md-5" p> <"col-sm-12 col-md-2" l> >>',
     rowCallback: function (row, data) {
 
       if ($.inArray(data.DT_RowId.toString(), selected) !== -1) {


### PR DESCRIPTION
List of changes:
- hide columns footer 
- move show entries button next to pagination
- little changes on the color/style of the table

![image](https://user-images.githubusercontent.com/53455/82696981-6c8e0500-9c68-11ea-87e9-aac0d8007e38.png)

This is very based on personal taste so I would understand that you may not want to merge it.

On a side note, I wasn't sure where the best place was to add some extra css, I added a new file `priv/static/css/kaffy.css`


