### PR TITLE
[fix](templates) Rendering the child template from layouts is deprecated

### DIFF
--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -315,7 +315,7 @@
                 <div class="alert alert-danger"><%= get_flash(@conn, :error) %></div>
             <% end %>
 
-            <%= render(@view_module, @view_template, assigns) %>
+            <%= @inner_content %>
         </div>
         <!-- /.container-fluid -->
 


### PR DESCRIPTION
Rendering the child template from layouts is deprecated in v1.5
Ref: https://gist.github.com/chrismccord/e53e79ef8b34adf5d8122a47db44d22f#update-your-layouts

I see that the requirement for Kaffy are 1.4, so we can leave this open until this change.