### PR TITLE
New field permission options

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ defmodule MyApp.Blog.PostAdmin do
       title: nil,
       status: %{choices: [{"Publish", "publish"}, {"Pending", "pending"}]},
       body: %{type: :textarea, rows: 4},
-      views: %{permission: :read},
+      views: %{create: :hidden, update: :readonly},
       settings: %{label: "Post Settings"}
     ]
   end
@@ -324,22 +324,24 @@ Options can be:
 - `:type` - can be any ecto type in addition to `:file`, `:textarea`, and `:richtext`.
 - `:rows` - an integer to indicate the number of rows for textarea fields.
 - `:choices` - a keyword list of option and values to restrict the input values that this field can accept.
-- `:permission` - can be either `:write` (field is editable) or `:read` (field is non-editable). It is `:write` by default.
+- `:create` - can be `:editable` which means it can be edited when creating a new record, or `:readonly` which means this field is visible when creating a new record but cannot be edited, or `:hidden` which means this field shouldn't be visible when creating a new record. It is `:editable` by default.
+- `:update` - can be `:editable` which means it can be edited when updating an existing record, or `:readonly` which means this field is visible when updating a record but cannot be edited, or `:hidden` which means this field shouldn't be visible when updating record. It is `:editable` by default.
 
 
 Result
 
 ![Customized show/edit page](demos/post_form_custom.png)
 
-Setting a field's type to `:richtext` will render a rich text editor like the following:
-
-![Rich text editor](demos/richtext.png)
-
 Notice that:
 
 - Even though the `status` field is of type `:string`, it is rendered as a `<select>` element with choices.
-- The `views` field is rendered as "readonly" because it has the `:read` permission.
+- The `views` field is rendered as "readonly" because it was set as `:readonly` for the update form.
 - `settigns` is an embedded schema. That's why it is rendered as such.
+
+
+Setting a field's type to `:richtext` will render a rich text editor like the following:
+
+![Rich text editor](demos/richtext.png)
 
 ### Search
 

--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -84,6 +84,15 @@ defmodule Kaffy.ResourceAdmin do
       :form_fields,
       ResourceSchema.form_fields(schema)
     )
+    |> set_default_field_options(schema)
+  end
+
+  defp set_default_field_options(fields, schema) do
+    Enum.map(fields, fn {f, o} ->
+      default_options = Kaffy.ResourceSchema.default_field_options(schema, f)
+      final_options = Map.merge(default_options, o || %{})
+      {f, final_options}
+    end)
   end
 
   @doc """

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -1,14 +1,12 @@
 defmodule Kaffy.ResourceForm do
   use Phoenix.HTML
 
-  def form_label(form, {field, options}) do
-    options = options || %{}
-    label_text = Map.get(options, :label, field)
-    form_label(form, label_text)
-  end
+  def form_label_string({field, options}), do: Map.get(options, :label, field)
+  def form_label_string(field) when is_atom(field), do: field
 
   def form_label(form, field) do
-    label(form, field)
+    label_text = form_label_string(field)
+    label(form, label_text)
   end
 
   def bare_form_field(resource, form, {field, options}) do

--- a/lib/kaffy_web/templates/resource/new.html.eex
+++ b/lib/kaffy_web/templates/resource/new.html.eex
@@ -6,11 +6,13 @@
 
 <div>
     <%= f = form_for(@changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :create, @context, @resource), method: :post, multipart: true) %>
-        <%= for field <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
-            <div class="form-group">
-                <%= Kaffy.ResourceForm.form_label(f, field) %>
-                <%= Kaffy.ResourceForm.form_field(@changeset, f, field, class: "form-control", conn: @conn) %>
-            </div>
+        <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
+            <%= if options.create != :hidden do %>
+                <div class="form-group">
+                    <%= Kaffy.ResourceForm.form_label(f, {field, options}) %>
+                    <%= Kaffy.ResourceForm.form_field(@changeset, f, {field, options}, class: "form-control", conn: @conn) %>
+                </div>
+            <% end %>
         <% end %>
         <div class="form-group">
             <%= link "Back", to: Kaffy.Utils.router().kaffy_resource_path(@conn, :index, @context, @resource), class: "btn btn-light" %> &nbsp;

--- a/lib/kaffy_web/templates/resource/show.html.eex
+++ b/lib/kaffy_web/templates/resource/show.html.eex
@@ -25,11 +25,13 @@
 
 <div>
     <%= f = form_for(@changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :update, @context, @resource, @changeset.data.id), method: :put, multipart: true) %>
-        <%= for field <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
-            <div class="form-group">
-                <%= Kaffy.ResourceForm.form_label(f, field) %>
-                <%= Kaffy.ResourceForm.form_field(@changeset, f, field, class: "form-control", conn: @conn) %>
-            </div>
+        <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
+            <%= if options.update != :hidden do %>
+                <div class="form-group">
+                    <%= Kaffy.ResourceForm.form_label(f, {field, options}) %>
+                    <%= Kaffy.ResourceForm.form_field(@changeset, f, {field, options}, class: "form-control", conn: @conn) %>
+                </div>
+            <% end %>
         <% end %>
 
         <div class="p-2">


### PR DESCRIPTION
This is related to #38 
It changes how field options are constructed and adds the `:create` and `:update` options, like this:
```elixir
api_key: %{create: :hidden, update: :readonly, label: "Key"}
```

