### PR TITLE
[fix](form) disable the field rather than using label

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -71,7 +71,7 @@ defmodule Kaffy.ResourceForm do
   defp build_html_input(schema, form, field, type, opts, readonly \\ false) do
     data = schema
     {conn, opts} = Keyword.pop(opts, :conn)
-    opts = Keyword.put(opts, :disabled, readonly)
+    opts = Keyword.put(opts, :readonly, readonly)
     schema = schema.__struct__
 
     case type do

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -58,14 +58,8 @@ defmodule Kaffy.ResourceForm do
       !is_nil(choices) ->
         select(form, field, choices, class: "custom-select")
 
-      permission == :readonly ->
-        content_tag(
-          :div,
-          label(form, field, Kaffy.ResourceSchema.kaffy_field_value(changeset.data, field))
-        )
-
       true ->
-        build_html_input(changeset.data, form, field, type, opts)
+        build_html_input(changeset.data, form, field, type, opts, permission == :readonly)
     end
   end
 
@@ -74,9 +68,10 @@ defmodule Kaffy.ResourceForm do
     build_html_input(changeset.data, form, field, type, opts)
   end
 
-  defp build_html_input(schema, form, field, type, opts) do
+  defp build_html_input(schema, form, field, type, opts, readonly \\ false) do
     data = schema
     {conn, opts} = Keyword.pop(opts, :conn)
+    opts = Keyword.put(opts, :disabled, readonly)
     schema = schema.__struct__
 
     case type do


### PR DESCRIPTION
Not a huge fan of label in a form, so tried this to display the field as disabled.
See if that works for you.

Nevertheless this is not working for me, trying to figure out why:
![image](https://user-images.githubusercontent.com/53455/82823089-35f1fd80-9ea7-11ea-810b-fdbcd45a6b7c.png)
