### PR TITLE
A successful create/edit will redirect to index

### DIFF
--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -98,19 +98,16 @@ defmodule KaffyWeb.ResourceController do
         changes = Map.get(params, resource, %{})
 
         case Kaffy.ResourceCallbacks.update_callbacks(conn, my_resource, entry, changes) do
-          {:ok, entry} ->
-            changeset = Kaffy.ResourceAdmin.update_changeset(my_resource, entry, %{})
-            conn = put_flash(conn, :info, "Saved #{resource} successfully")
+          {:ok, _entry} ->
+            conn = put_flash(conn, :info, "#{resource_name} saved successfully")
+            fields = Kaffy.ResourceAdmin.index(my_resource)
 
-            render(conn, "show.html",
+            render(conn, "index.html",
               layout: {KaffyWeb.LayoutView, "app.html"},
-              changeset: changeset,
               context: context,
               resource: resource,
-              my_resource: my_resource,
-              resource_name: resource_name,
-              schema: schema,
-              entry: entry
+              fields: fields,
+              my_resource: my_resource
             )
 
           {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -185,7 +185,9 @@ defmodule KaffyWeb.ResourceController do
             case Map.get(params, "submit") do
               "Save" ->
                 put_flash(conn, :info, "Created a new #{resource_name} successfully")
-                |> redirect_to_resource(context, resource, entry)
+                |> redirect(
+                  to: Kaffy.Utils.router().kaffy_resource_path(conn, :index, context, resource)
+                )
 
               _ ->
                 put_flash(conn, :info, "Created a new #{resource_name} successfully")


### PR DESCRIPTION
In order to reduce clicks, I feel that when you create or edit a record, if it's successful you probably want to go to the list of records, rather than seeing the record you just edited.

Not trying to copy all the behaviour from django-admin, but it feels to me that staying on the same screen is not what most people would want.

Thoughts?
 