### PR TITLE
[fix](form) add new input type boolean_switch & boolean_checkbox

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -125,9 +125,7 @@ defmodule Kaffy.ResourceForm do
       :decimal ->
         text_input(form, field, opts)
 
-      :boolean ->
-
-      :boolean_checkbox ->
+      t when t in [:boolean, :boolean_checkbox] ->
         checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
         label_opts = Keyword.put(opts, :class, "custom-control-label")
 

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -126,7 +126,28 @@ defmodule Kaffy.ResourceForm do
         text_input(form, field, opts)
 
       :boolean ->
-        checkbox(form, field)
+
+      :boolean_checkbox ->
+        checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
+        label_opts = Keyword.put(opts, :class, "custom-control-label")
+
+        [
+          {:safe, ~s(<div class="custom-control custom-checkbox">)},
+          checkbox(form, field, checkbox_opts),
+          label(form, field, label_opts),
+          {:safe, "</div>"}
+        ]
+
+      :boolean_switch ->
+        checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
+        label_opts = Keyword.put(opts, :class, "custom-control-label")
+
+        [
+          {:safe, ~s(<div class="custom-control custom-switch">)},
+          checkbox(form, field, checkbox_opts),
+          label(form, field, label_opts),
+          {:safe, "</div>"}
+        ]
 
       :map ->
         value = Map.get(data, field, "")


### PR DESCRIPTION
The look of the actual checkbox needed some improvement, personally I also like using switch and bootstrap4 have one included.

I added 2 new type `:boolean_checkbox` & `:boolean_switch`, and `boolean` will fallback to `:boolean_checkbox`.

![image](https://user-images.githubusercontent.com/53455/82833084-562cb700-9ebd-11ea-8c9f-b30ba79f2321.png)

![image](https://user-images.githubusercontent.com/53455/82833108-6b094a80-9ebd-11ea-98f7-47b0ed0a4021.png)

I would like to get rid of the top label too... but that would require a bigger refactoring as we will have to remove it from the template eex file. 

Let me know what you think?