### PR TITLE
[fix](utils) simplify the check version to use inner_content

### DIFF
--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -23,11 +23,6 @@ defmodule Kaffy.Utils do
     String.starts_with?(version, "1.4.")
   end
 
-  def phoenix_1_5?() do
-    version = get_version_of(:phoenix)
-    String.starts_with?(version, "1.5.")
-  end
-
   def router do
     Module.concat(env(:router), Helpers)
   end

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -111,8 +111,7 @@
 
                         <%= if Kaffy.Utils.phoenix_1_4?() do %>
                             <%= render(@view_module, @view_template, assigns) %>
-                        <% end %>
-                        <%= if Kaffy.Utils.phoenix_1_5?() do %>
+                        <% else %>
                             <%= @inner_content %>
                         <% end %>
                     </div>

--- a/lib/kaffy_web/templates/layout/app_backup.html.eex
+++ b/lib/kaffy_web/templates/layout/app_backup.html.eex
@@ -329,8 +329,7 @@
 
             <%= if Kaffy.Utils.phoenix_1_4?() do %>
               <%= render(@view_module, @view_template, assigns) %>
-            <% end %>
-            <%= if Kaffy.Utils.phoenix_1_5?() do %>
+            <% else %>
               <%= @inner_content %>
             <% end %>
         </div>


### PR DESCRIPTION
I feel that this approach is better to handle the depreciation of `render(@view_module, @view_template, assigns)`, we can take the assumption that `inner_content` is here to stay so we want to make sure that code will work with future version of phoenix (1.6 or above)

Feel free to ignore the PR or comment if you feel otherwise