### PR TITLE
[fix](table) natural behaviour on checkboxes

### DIFF
--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -142,6 +142,7 @@
     <script src="/kaffy/assets/js/off-canvas.js"></script>
     <script src="/kaffy/assets/js/hoverable-collapse.js"></script>
     <script src="/kaffy/assets/js/misc.js"></script>
+    <script src="/kaffy/assets/js/select-all-checkbox.js"></script>
     <script src="/kaffy/assets/js/dashboard.js"></script>
     <script src="/kaffy/assets/js/todolist.js"></script>
   </body>

--- a/lib/kaffy_web/templates/resource/_list_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_list_table.html.eex
@@ -11,7 +11,7 @@
                 <% {field, filters} = Kaffy.ResourceSchema.kaffy_field_filters(@my_resource[:schema], field) %>
                 <%= if filters do %>
                     <th class="bg-light">
-                        <select class="kaffy-filter custom-select" id="kaffy-field-<%= index %>" data-field-name="<%= Kaffy.ResourceSchema.kaffy_field_name(@my_resource[:schema], field) %>">
+                         <select class="kaffy-filter custom-select" id="kaffy-field-<%= index %>" data-field-name="<%= Kaffy.ResourceSchema.kaffy_field_name(@my_resource[:schema], field) %>">
                             <option value="">All</option>
                             <%= for {human, machine} <- filters do %>
                                 <option value="<%= machine %>"><%= human %></option>

--- a/lib/kaffy_web/templates/resource/_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_table.html.eex
@@ -8,7 +8,7 @@
             <tr>
                 <td>
                     <div class="custom-control custom-checkbox">
-                        <input type="checkbox" class="custom-control-input kaffy-resource-checkbox" id="kaffy-select-<%= entry.id %>" name="resource" value="<%= entry.id %>"/>
+                        <input type="checkbox" class="custom-control-input select-item kaffy-resource-checkbox" id="kaffy-select-<%= entry.id %>" name="resource" value="<%= entry.id %>"/>
                         <label class="custom-control-label" for="kaffy-select-<%= entry.id %>"></label>
                     </div>
                 </td>

--- a/lib/kaffy_web/templates/resource/_table_header.html.eex
+++ b/lib/kaffy_web/templates/resource/_table_header.html.eex
@@ -1,7 +1,7 @@
 <tr class="bg-light">
     <th>
         <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input kaffy-resource-checkbox" id="kaffy-select-all" name="all-resources" value=""/>
+            <input type="checkbox" class="custom-control-input select-all kaffy-resource-checkbox" id="kaffy-select-all" name="all-resources" value=""/>
             <label class="custom-control-label" for="kaffy-select-all"></label>
         </div>
     </th>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -6,6 +6,7 @@
           <h3>
             <%= Kaffy.ResourceAdmin.plural_name(@my_resource) %><br/>
             <span class="badge badge-secondary">(~ <%= @filtered_count %> records)</span>
+            <div id="checkbox-selected-count" class="checkbox-selected-count float-right"></div>
           </h3>
         </div>
         <div class="col-auto">

--- a/priv/static/assets/css/kaffy.css
+++ b/priv/static/assets/css/kaffy.css
@@ -2,6 +2,10 @@
  * custom Kaffy Css
  */
 
+.checkbox-selected-count {
+    margin-left: 0.5rem;
+}
+
 .sidebar .nav .nav-item:hover {
     background: #1240c4;
 }

--- a/priv/static/assets/js/select-all-checkbox.js
+++ b/priv/static/assets/js/select-all-checkbox.js
@@ -1,0 +1,66 @@
+(function ($) {
+  'use strict';
+
+  //button select all or cancel
+  $("#select-all").click(function () {
+    var all = $("input.select-all")[0];
+    all.checked = !all.checked
+    var checked = all.checked;
+    $("input.select-item").each(function (index, item) {
+      item.checked = checked;
+    });
+    checkSelected();
+  });
+
+  //button select invert
+  $("#select-invert").click(function () {
+    $("input.select-item").each(function (index, item) {
+      item.checked = !item.checked;
+    });
+    checkSelected();
+  });
+
+  //button get selected info
+  $("#selected").click(function () {
+    var items = [];
+    $("input.select-item:checked:checked").each(function (index, item) {
+      items[index] = item.value;
+    });
+    if (items.length < 1) {
+      alert("no selected items!!!");
+    } else {
+      var values = items.join(',');
+      console.log(values);
+      var html = $("<div></div>");
+      html.html("selected:" + values);
+      html.appendTo("body");
+    }
+  });
+
+  //column checkbox select all or cancel
+  $("input.select-all").click(function () {
+    var checked = this.checked;
+    $("input.select-item").each(function (index, item) {
+      item.checked = checked;
+    });
+    checkSelected();
+  });
+
+  //check selected items
+  $("input.select-item").click(function () {
+    var checked = this.checked;
+    console.log(checked);
+    checkSelected();
+  });
+
+  //check is all selected
+  function checkSelected() {
+    var all = $("input.select-all")[0];
+    var total = $("input.select-item").length;
+    var len = $("input.select-item:checked:checked").length;
+    var html = $('<span class="badge badge-secondary">' + len + " / " + total + " selected" + '</span>');
+    $("#checkbox-selected-count").html(html);
+    all.checked = len === total;
+  }
+
+})(jQuery);


### PR DESCRIPTION
Wanted to clarify the current behaviour of select all checkboxes:
![image](https://user-images.githubusercontent.com/53455/83760354-2166ef80-a675-11ea-93f8-3a0fd2ad60e3.png)

 it doesn't select all the underlining checkboxes, the way I would expect it.
https://examples.bootstrap-table.com/#issues/1167.html

I suppose it was made that way, but I found that behaviour restrictive.
For instance some time, you might want to select all and unselect a few.

Here with this PR I try to remedy to this:
![image](https://user-images.githubusercontent.com/53455/83764579-65102800-a67a-11ea-990c-03a0cf15b98f.png)

Additionally I display when selecting a little tag with the number of selected records.

Thoughts?
