### PR TITLE
move scheduled tasks out of ResourceAdmin and into their own modules.

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -337,29 +337,6 @@ defmodule Kaffy.ResourceAdmin do
     |> Enum.at(0)
   end
 
-  def scheduled_tasks(resource) do
-    Utils.get_assigned_value_or_default(resource, :scheduled_tasks, [])
-  end
-
-  def collect_tasks() do
-    Enum.reduce(Kaffy.Utils.contexts(), [], fn c, all ->
-      tasks =
-        Enum.reduce(Kaffy.Utils.schemas_for_context(c), [], fn {_, resource}, all ->
-          all ++ Kaffy.ResourceAdmin.scheduled_tasks(resource)
-        end)
-
-      all ++ tasks
-    end)
-  end
-
-  def tasks_info() do
-    children = DynamicSupervisor.which_children(KaffyTaskSupervisor)
-
-    Enum.map(children, fn {_, p, _, _} ->
-      GenServer.call(p, :info)
-    end)
-  end
-
   def custom_links(resource, location \\ nil) do
     links = Utils.get_assigned_value_or_default(resource, :custom_links, [])
 

--- a/lib/kaffy/scheduler/supervisor.ex
+++ b/lib/kaffy/scheduler/supervisor.ex
@@ -3,7 +3,7 @@ defmodule Kaffy.Scheduler.Supervisor do
 
   def start_link(args) do
     result = DynamicSupervisor.start_link(__MODULE__, args, name: KaffyTaskSupervisor)
-    tasks = Kaffy.ResourceAdmin.collect_tasks()
+    tasks = Kaffy.Tasks.collect_tasks()
 
     for task <- tasks do
       DynamicSupervisor.start_child(KaffyTaskSupervisor, {Kaffy.Scheduler.Task, task})

--- a/lib/kaffy/tasks.ex
+++ b/lib/kaffy/tasks.ex
@@ -1,0 +1,19 @@
+defmodule Kaffy.Tasks do
+  def collect_tasks() do
+    Kaffy.Utils.get_task_modules()
+    |> Enum.map(fn m ->
+      m.__info__(:functions)
+      |> Enum.filter(fn {f, _} -> String.starts_with?(to_string(f), "task_") end)
+      |> Enum.map(fn {f, _} -> apply(m, f, []) end)
+    end)
+    |> List.flatten()
+  end
+
+  def tasks_info() do
+    children = DynamicSupervisor.which_children(KaffyTaskSupervisor)
+
+    Enum.map(children, fn {_, p, _, _} ->
+      GenServer.call(p, :info)
+    end)
+  end
+end

--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -365,4 +365,8 @@ defmodule Kaffy.Utils do
     end)
     |> Enum.sort()
   end
+
+  def get_task_modules() do
+    env(:scheduled_tasks, [])
+  end
 end

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -46,7 +46,7 @@
               </li>
             <% end %>
 
-            <% tasks = Kaffy.ResourceAdmin.tasks_info() %>
+            <% tasks = Kaffy.Tasks.tasks_info() %>
 
             <%= if not Enum.empty?(tasks) do %>
               <li class="nav-item">

--- a/lib/kaffy_web/templates/task/index.html.eex
+++ b/lib/kaffy_web/templates/task/index.html.eex
@@ -12,7 +12,7 @@
             <th>Last Failed Run (UTC)</th>
         </tr>
 
-        <%= for task <- Kaffy.ResourceAdmin.tasks_info() do %>
+        <%= for task <- Kaffy.Tasks.tasks_info() do %>
             <tr>
                 <td><%= task.name %></td>
                 <td><%= task.every %></td>


### PR DESCRIPTION
Moving scheduled tasks away from `ResourceAdmin`.
This PR makes scheduled tasks live inside their own modules.

```elixir
# config.exs
config :kaffy,
  # other settings
  scheduled_tasks: [
    MyApp.Kaffy.Tasks
  ]

# tasks module
defmodule Bakery.Kaffy.Tasks do
  def task_cache_product_count() do
    %{
      name: "Cache Product Count",
      initial_value: 0,
      every: 300,
      action: fn _v ->
        count = Bakery.Products.count_products()
        {:ok, count}
      end
    }
  end

  defp get_product_count() do
    Bakery.Products.count_products()
  end
end
```

Any function inside the module that starts with `task_` is considered a scheduled task.