### PR TITLE
Adding "method" option for custom links

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -369,7 +369,7 @@ defmodule Kaffy.ResourceAdmin do
       :sub -> Enum.filter(links, fn l -> Map.get(l, :location, :sub) == :sub end)
     end
     |> Enum.sort_by(fn l -> Map.get(l, :order, 999) end)
-    |> Enum.map(fn l -> Map.merge(%{target: "_self", icon: "link"}, l) end)
+    |> Enum.map(fn l -> Map.merge(%{target: "_self", icon: "link", method: :get}, l) end)
   end
 
   def collect_links(location) do

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -59,7 +59,7 @@
 
             <%= for custom_link <- Kaffy.ResourceAdmin.collect_links(:top) do %>
               <li class="nav-item">
-                <%= link to: custom_link.url, class: "nav-link", target: custom_link.target do %>
+                <%= link to: custom_link.url, method: custom_link.method, class: "nav-link", target: custom_link.target do %>
                   <span class="menu-title"><%= custom_link.name %></span>
                   <i class="fas fa-<%= custom_link.icon %> menu-icon"></i>
                 <% end %>


### PR DESCRIPTION
This allows custom links to do "post" or "delete" HTTP requests. For example, for logout links.