### PR TITLE
WIP: overwrite update, insert, delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,40 @@ defmodule MyApp.Blog.PostAdmin do
 end
 ```
 
+### Overwrite actions
+
+Sometimes you may need to overwrite the way Kaffy is creating, updating, or deleting records.
+
+You can define you own Admin function to perform those actions. This can be useful if you are creating complex records, importing files, etc...
+
+The function that can be overwriten are:
+
+- `insert/2`
+- `update/2`
+- `delete/2`
+
+`insert/2`, `update/2` & `delete/2` functions are passed the current `conn` and a changeset.
+They must return `{:ok, record}` to continue.
+
+```elixir
+defmodule MyApp.Blog.PostAdmin do
+  def insert(conn, changeset) do
+    entry = Post.create_complex_post(conn.params)
+    {:ok, entry}
+  end
+
+  def update(conn, changeset) do
+    entry = Post.update_complex_post(conn.params["id"])
+    {:ok, entry}
+  end
+
+  def delete(conn, changeset) do
+    entry = Post.delete_complex_post(conn.params["id"])
+    {:ok, entry}
+  end
+end
+```
+
 ### Scheduled Tasks
 
 Kaffy supports simple scheduled tasks. Tasks are functions that are run periodically. Behind the scenes, they are put inside `GenServer`s and supervised with a `DynamicSupervisor`.

--- a/README.md
+++ b/README.md
@@ -597,14 +597,14 @@ There are a few callbacks that are called every time you create, update, or dele
 
 These callbacks are:
 
-- `before_create/2`
+- `before_insert/2`
 - `before_update/2`
 - `before_delete/2`
 - `before_save/2`
 - `after_save/2`
 - `after_delete/2`
 - `after_update/2`
-- `after_create/2`
+- `after_insert/2`
 
 `before_*` functions are passed the current `conn` and a changeset. `after_*` functions are passed the current `conn` and the record itself. With the exception of `before_delete/2` and `after_delete/2` which are both passed the current `conn` and the record itself.
 
@@ -620,11 +620,11 @@ To prevent the chain from continuing and roll back any changes:
 
 When creating a new record, the following functions are called in this order:
 
-- `before_create/2`
+- `before_insert/2`
 - `before_save/2`
 - inserting the record happens here: `Repo.insert/1`
 - `after_save/2`
-- `after_create/2`
+- `after_insert/2`
 
 When updating an existing record, the following functions are called in this order:
 
@@ -644,14 +644,14 @@ It's important to know that all callbacks are run inside a transaction. So in ca
 
 ```elixir
 defmodule MyApp.Blog.PostAdmin do
-  def before_create(conn, changeset) do
+  def before_insert(conn, changeset) do
     case conn.assigns.user.username == "aesmail" do
       true -> {:error, changeset} # aesmail should never create a post
       false -> {:ok, changeset}
     end
   end
 
-  def after_create(_conn, post) do
+  def after_insert(_conn, post) do
     {:error, post, "This will prevent posts from being created"}
   end
 

--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -27,7 +27,7 @@ defmodule Kaffy.ResourceCallbacks do
     with {:ok, entry} <- insert(conn, resource, changeset) do
       {:ok, entry}
     else
-      {:not_found} ->
+      {:error, :not_found} ->
         Kaffy.Utils.repo().insert(changeset)
 
       unexpected_error ->
@@ -59,7 +59,7 @@ defmodule Kaffy.ResourceCallbacks do
     with {:ok, entry} <- update(conn, resource, changeset) do
       {:ok, entry}
     else
-      {:not_found} ->
+      {:error, :not_found} ->
         Kaffy.Utils.repo().update(changeset)
 
       unexpected_error ->
@@ -88,7 +88,7 @@ defmodule Kaffy.ResourceCallbacks do
     with {:ok, entry} <- delete(conn, resource, changeset) do
       {:ok, entry}
     else
-      {:not_found} ->
+      {:error, :not_found} ->
         Kaffy.Utils.repo().delete(changeset)
 
       unexpected_error ->
@@ -110,7 +110,7 @@ defmodule Kaffy.ResourceCallbacks do
     Utils.get_assigned_value_or_default(
       resource,
       :insert,
-      {:not_found},
+      {:error, :not_found},
       [conn, changeset],
       false
     )
@@ -154,7 +154,7 @@ defmodule Kaffy.ResourceCallbacks do
     Utils.get_assigned_value_or_default(
       resource,
       :update,
-      {:not_found},
+      {:error, :not_found},
       [conn, changeset],
       false
     )
@@ -186,7 +186,7 @@ defmodule Kaffy.ResourceCallbacks do
     Utils.get_assigned_value_or_default(
       resource,
       :delete,
-      {:not_found},
+      {:error, :not_found},
       [conn, changeset],
       false
     )

--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -9,11 +9,11 @@ defmodule Kaffy.ResourceCallbacks do
 
     repo.transaction(fn ->
       result =
-        with {:ok, changeset} <- before_create(conn, resource, changeset),
+        with {:ok, changeset} <- before_insert(conn, resource, changeset),
              {:ok, changeset} <- before_save(conn, resource, changeset),
              {:ok, entry} <- exec_insert(conn, resource, changeset),
              {:ok, entry} <- after_save(conn, resource, entry),
-             do: after_create(conn, resource, entry)
+             do: after_insert(conn, resource, entry)
 
       case result do
         {:ok, entry} -> entry
@@ -96,10 +96,10 @@ defmodule Kaffy.ResourceCallbacks do
     end
   end
 
-  defp before_create(conn, resource, changeset) do
+  defp before_insert(conn, resource, changeset) do
     Utils.get_assigned_value_or_default(
       resource,
-      :before_create,
+      :before_insert,
       {:ok, changeset},
       [conn, changeset],
       false
@@ -116,10 +116,10 @@ defmodule Kaffy.ResourceCallbacks do
     )
   end
 
-  defp after_create(conn, resource, entry) do
+  defp after_insert(conn, resource, entry) do
     Utils.get_assigned_value_or_default(
       resource,
-      :after_create,
+      :after_insert,
       {:ok, entry},
       [conn, entry],
       false

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -143,7 +143,7 @@ defmodule Kaffy.ResourceSchema do
     Kaffy.ResourceAdmin.humanize_term(field)
   end
 
-  def kaffy_field_value(schema, {field, options}) do
+  def kaffy_field_value(conn, schema, {field, options}) do
     default_value = kaffy_field_value(schema, field)
     ft = Kaffy.ResourceSchema.field_type(schema.__struct__, field)
     value = Map.get(options || %{}, :value)
@@ -162,7 +162,7 @@ defmodule Kaffy.ResourceSchema do
         end
 
       Kaffy.Utils.is_module(ft) && Keyword.has_key?(ft.__info__(:functions), :render_index) ->
-        ft.render_index(schema, field, options)
+        ft.render_index(conn, schema, field, options)
 
       is_map(value) ->
         Kaffy.Utils.json().encode!(value, escape: :html_safe, pretty: true)

--- a/lib/kaffy_web/templates/resource/_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_table.html.eex
@@ -14,9 +14,9 @@
                 </td>
                 <%= for {field, index} <- Enum.with_index(@fields) do %>
                     <%= if index == 0 do %>
-                        <td><%= link Kaffy.ResourceSchema.kaffy_field_value(entry, field), to: Kaffy.Utils.router().kaffy_resource_path(@conn, :show, @context, @resource, entry) %></td>
+                        <td><%= link Kaffy.ResourceSchema.kaffy_field_value(@conn, entry, field), to: Kaffy.Utils.router().kaffy_resource_path(@conn, :show, @context, @resource, entry) %></td>
                     <% else %>
-                        <td><%= Kaffy.ResourceSchema.kaffy_field_value(entry, field) %></td>
+                        <td><%= Kaffy.ResourceSchema.kaffy_field_value(@conn, entry, field) %></td>
                     <% end %>
                 <% end %>
             </tr>


### PR DESCRIPTION
In relation to https://github.com/aesmail/kaffy/issues/85
I found that the suggested solution lack of flexibility because it will mean that one will need to refactor a lot of code in his phoenix project rather than using their own existing functions.

This can become very complex, in my example, we upload & convert images, insert in the DB and then also generate thumbnail and insert them too, for reference: https://github.com/areski/ex-chitchat/blob/master/lib/chit_chat_web/controllers/upload_controller.ex#L33

I think there is also many situation where this might happen.

Therefore, in the same way we have many callback (before/after/create etc...) we could introduce a new method that can be defined in the admin module: `overwritten_create`, along with some other `overwritten_update` & `overwritten_delete`

`overwritten_create` will allow you to bypass Kaffy repo insert and write your own.

Let me know what you think about it, I will continue the WIP if you think that's acceptable.

