### PR TITLE
[fix](form) improve alert boxes

### DIFF
--- a/lib/kaffy/resource_error.ex
+++ b/lib/kaffy/resource_error.ex
@@ -21,7 +21,11 @@ defmodule Kaffy.ResourceError do
                     end
 
                   content_tag :div, class: "alert alert-danger" do
-                    content_tag(:span, to_string(field) <> " " <> msg)
+                    [
+                      content_tag(:i, "", class: "fa fa-exclamation-circle"),
+                      content_tag(:strong, "Error: "),
+                      content_tag(:span, Kaffy.ResourceAdmin.humanize_term(field) <> " " <> msg)
+                    ]
                   end
                 end)
       end

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -116,11 +116,25 @@
 
         <div class="main-panel">
           <div class="content-wrapper">
+            <%= if get_flash(@conn, :success) do %>
+                <div class="alert alert-success">
+                  <i class="fa fa-check"></i><strong>Success: </strong> <%= get_flash(@conn, :info) %>
+                </div>
+            <% end %>
             <%= if get_flash(@conn, :info) do %>
-                <div class="alert alert-success"><%= get_flash(@conn, :info) %></div>
+                <div class="alert alert-info">
+                  <i class="fa fa-info-circle"></i><strong>Info: </strong> <%= get_flash(@conn, :info) %>
+                </div>
+            <% end %>
+            <%= if get_flash(@conn, :warning) do %>
+                <div class="alert alert-warning">
+                  <i class="fa fa-exclamation-triangle"></i><strong>Warning: </strong> <%= get_flash(@conn, :error) %>
+                </div>
             <% end %>
             <%= if get_flash(@conn, :error) do %>
-                <div class="alert alert-danger"><%= get_flash(@conn, :error) %></div>
+                <div class="alert alert-danger">
+                  <i class="fa fa-exclamation-circle"></i><strong>Error: </strong> <%= get_flash(@conn, :error) %>
+                </div>
             <% end %>
 
             <%= if Kaffy.Utils.phoenix_version?("1.4.") do %>

--- a/priv/static/assets/css/kaffy.css
+++ b/priv/static/assets/css/kaffy.css
@@ -148,3 +148,47 @@
 a.kaffy-order-field {
     cursor:pointer;
 }
+
+
+/* Improved Alert box */
+.alert{padding: 20px; transition:all .3s ease;}
+.alert:hover, .alert:focus{transform:scale(1.04); -webkit-box-shadow: 0 8px 20px #e8e8e8;box-shadow: 0 8px 20px #e8e8e8;}
+.alert .close{opacity:0; transition:opacity .3s ease;}
+.alert:hover .close, .alert:focus .close{opacity:.2;}
+.alert i{min-width:30px; text-align:center;}
+
+.alert-primary{
+    color: #FFFFFF;
+    background: #4285F4;
+    border-color: #387ae4;
+}
+
+.alert-secondary{
+    color: #5a6ca1;
+    background: #b6c6f7;
+    border-color: #97a8da;
+}
+
+.alert-success{
+    color: #FFFFFF;
+    background: #00C851;
+    border-color: #02af47;
+}
+
+.alert-info{
+    color: #FFFFFF;
+    background: #5ABBDB;
+    border-color: #4ba5c4;
+}
+
+.alert-warning{
+    color: #FFFFFF;
+    background: #ffbb33;
+    border-color: #e9a826;
+}
+
+.alert-danger{
+    color: #FFFFFF;
+    background: #fa5e5e;
+    border-color: #db4646;
+}


### PR DESCRIPTION
The alert box weren't using the color scheme from our admin template additionally, I wanted to make some little improvements.

From:
![image](https://user-images.githubusercontent.com/53455/84597689-fc892e00-ae65-11ea-839f-ec78c400a2ce.png)

To:
![image](https://user-images.githubusercontent.com/53455/84597694-0448d280-ae66-11ea-97fd-e805be576991.png)

I prepared also the css of other type of alert messages (info, warning, etc...)
