### PR TITLE
Remove class from assoc field in form

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -246,7 +246,7 @@ defmodule Kaffy.ResourceForm do
             target_context = Kaffy.Utils.get_context_for_schema(assoc)
             target_resource = Kaffy.Utils.get_schema_key(target_context, assoc)
 
-            content_tag :div, class: "input-group col-md-2" do
+            content_tag :div, class: "input-group" do
               [
                 number_input(form, field,
                   class: "form-control",


### PR DESCRIPTION
* Remove class from assoc field in form to fix bug
* With `col-md-2` the id isn't visible at all screen sizes
* Closes #100