### PR TITLE
Fix bug including virtual fields in search query

### DIFF
--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -232,9 +232,11 @@ defmodule Kaffy.ResourceSchema do
 
   def search_fields(resource) do
     schema = resource[:schema]
+    persisted_fields = schema.__schema__(:fields)
 
     Enum.filter(fields(schema), fn f ->
-      field_type(schema, f).type in [:string, :textarea, :richtext]
+      field_type(schema, f).type in [:string, :textarea, :richtext] &&
+        f in persisted_fields
     end)
     |> Enum.map(fn {f, _} -> f end)
   end


### PR DESCRIPTION
* Fix bug where virtual fields are included in the search query
* If a virtual field is a string, textarea, or richtext it is included
* Causes an error when the database cannot find the column
* Uses `schema.__schema__(:fields)` which only returns persisted fields
* Closes #104