### PR TITLE
Fix bug in search query

### DIFF
--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -238,8 +238,10 @@ defmodule Kaffy.ResourceSchema do
     persisted_fields = schema.__schema__(:fields)
 
     Enum.filter(fields(schema), fn f ->
+      field_name = elem(f, 0)
+
       field_type(schema, f).type in [:string, :textarea, :richtext] &&
-        f in persisted_fields
+        field_name in persisted_fields
     end)
     |> Enum.map(fn {f, _} -> f end)
   end


### PR DESCRIPTION
* Bug introduced in pull request #105 to fix virtual fields bug
* `f` is a two element tuple with the field name as the 1st element
* Need to extract 1st tuple element to compare with persisted fields

I realized today I broke search with my pull request yesterday.  I extracted the field name into a variable.  I wasn't sure if you prefer to create a function to get the 1st element.