### PR TITLE
Multistep actions

### DIFF
--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -344,8 +344,15 @@ defmodule KaffyWeb.ResourceController do
     entries = Kaffy.ResourceQuery.fetch_list(my_resource, ids)
     actions = Kaffy.ResourceAdmin.list_actions(my_resource, conn)
     [action_record] = Keyword.get_values(actions, action_key)
+    kaffy_inputs = Map.get(params, "kaffy-input", %{})
 
-    case action_record.action.(conn, entries) do
+    result =
+      case Map.get(action_record, :inputs, []) do
+        [] -> action_record.action.(conn, entries)
+        _ -> action_record.action.(conn, entries, kaffy_inputs)
+      end
+
+    case result do
       :ok ->
         put_flash(conn, :success, "Action performed successfully")
         |> redirect(to: Kaffy.Utils.router().kaffy_resource_path(conn, :index, context, resource))

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -34,9 +34,16 @@
                 </button>
                 <div class="dropdown-menu">
                   <%= for {action_key, options} <- list_actions do %>
-                    <%= form_tag(Kaffy.Utils.router().kaffy_resource_path(@conn, :list_action, @context, @resource, to_string(action_key)), method: :post, class: "list-action") %>
-                      <input type="submit" name="submit" value="<%= options.name %>" class="dropdown-item" />
-                    </form>
+                      <% extra_inputs = Map.get(options, :inputs, []) %>
+                      <%= if !Enum.empty?(extra_inputs) do %>
+                        <button type="button" data-toggle="modal" class="dropdown-item" data-target="#<%= action_key %>_modal">
+                          <%= options.name %>
+                        </button>
+                      <% else %>
+                        <%= form_tag(Kaffy.Utils.router().kaffy_resource_path(@conn, :list_action, @context, @resource, to_string(action_key)), method: :post, class: "list-action", id: "#{action_key}_form") %>
+                          <input type="submit" name="submit" value="<%= options.name %>" class="dropdown-item kaffy-list-action-submit" id="<%= action_key %>_submit" />
+                        </form>
+                      <% end %>
                   <% end %>
                 </div>
               </div>
@@ -71,3 +78,40 @@
   <input id="kaffy-order-field" type="hidden" name="<%= to_string(:_of) %>" value="<%= Map.get(@params, "_of", "id") %>" />
   <input id="kaffy-order-way" type="hidden" name="<%= to_string(:_ow) %>" value="<%= Map.get(@params, "_ow", "desc") %>" />
 </form>
+
+
+<% list_actions = Kaffy.ResourceAdmin.list_actions(@my_resource, @conn) %>
+<%= for {action_key, options} <- list_actions do %>
+  <% extra_inputs = Map.get(options, :inputs, []) %>
+  <%= if !Enum.empty?(extra_inputs) do %>
+    <%= form_tag(Kaffy.Utils.router().kaffy_resource_path(@conn, :list_action, @context, @resource, to_string(action_key)), method: :post, class: "list-action", id: "#{action_key}_form") %>
+      <div class="modal fade" id="<%= action_key %>_modal" tabindex="-1" role="dialog" aria-labelledby="<%= action_key %>_modal_label" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h5 class="modal-title" id="<%= action_key %>_modal_label">Extra Details</h5>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                      </button>
+                  </div>
+                  <div class="modal-body">
+                    <%= for extra <- extra_inputs do %>
+                      <div class="form-group">
+                        <label><%= extra.title %></label>
+                        <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                      </div>
+                    <% end %>
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-light" data-dismiss="modal">Cancel</button>
+                      <button type="submit" class="btn btn- kaffy-list-action-submit" id="<%= action_key %>_submit">Continue</button>
+                  </div>
+              </div>
+          </div>
+      </div>
+      <button type="button" data-toggle="modal" class="dropdown-item" data-target="#<%= action_key %>_modal">
+        <%= options.name %>
+      </button>
+    <% end %>
+  </form>
+<% end %>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -89,7 +89,7 @@
           <div class="modal-dialog" role="document">
               <div class="modal-content">
                   <div class="modal-header">
-                      <h5 class="modal-title" id="<%= action_key %>_modal_label">Extra Details</h5>
+                      <h5 class="modal-title" id="<%= action_key %>_modal_label"><%= options.name %></h5>
                       <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                       <span aria-hidden="true">&times;</span>
                       </button>
@@ -104,14 +104,11 @@
                   </div>
                   <div class="modal-footer">
                       <button type="button" class="btn btn-light" data-dismiss="modal">Cancel</button>
-                      <button type="submit" class="btn btn- kaffy-list-action-submit" id="<%= action_key %>_submit">Continue</button>
+                      <button type="submit" class="btn btn-primary kaffy-list-action-submit" id="<%= action_key %>_submit">Continue</button>
                   </div>
               </div>
           </div>
       </div>
-      <button type="button" data-toggle="modal" class="dropdown-item" data-target="#<%= action_key %>_modal">
-        <%= options.name %>
-      </button>
     <% end %>
   </form>
 <% end %>

--- a/priv/static/assets/js/misc.js
+++ b/priv/static/assets/js/misc.js
@@ -101,6 +101,19 @@ var lightColor = getComputedStyle(document.body).getPropertyValue('--light');
       dateFormat: "Z"
     });
 
+    // $(".kaffy-list-action-submit").click(function () {
+    //   var button = $(this);
+    //   var form_id = button.parents("form.list-action").attr("id");
+    //   var inputs = [];
+    //   button.siblings("input.kaffy-list-action-input").each(function () {
+    //     var input = $(this);
+    //     inputs.push({ name: input.attr('name'), value: input.val() });
+    //   });
+    //   console.log(form_id);
+    //   console.log(inputs);
+    //   return false;
+    // });
+
   });
 
 

--- a/priv/static/assets/js/misc.js
+++ b/priv/static/assets/js/misc.js
@@ -100,20 +100,6 @@ var lightColor = getComputedStyle(document.body).getPropertyValue('--light');
       enableTime: true,
       dateFormat: "Z"
     });
-
-    // $(".kaffy-list-action-submit").click(function () {
-    //   var button = $(this);
-    //   var form_id = button.parents("form.list-action").attr("id");
-    //   var inputs = [];
-    //   button.siblings("input.kaffy-list-action-input").each(function () {
-    //     var input = $(this);
-    //     inputs.push({ name: input.attr('name'), value: input.val() });
-    //   });
-    //   console.log(form_id);
-    //   console.log(inputs);
-    //   return false;
-    // });
-
   });
 
 


### PR DESCRIPTION
This PR adds the ability to create multi-step actions. This is something I needed for a while.

In the following example, `change_price` is a multi-step action while the others are "single-step" actions.

```elixir
def list_actions(_) do
    [
      change_price: %{
        name: "Change the price",
        inputs: [
          %{name: "new_price", title: "New Price", default: "3"}
        ],
        action: fn _conn, products, params -> change_price(products, params) end
      },
      soldout: %{name: "Mark as soldout", action: fn _, products -> list_soldout(products) end},
      restock: %{name: "Bring back", action: fn _, products -> bring_back(products) end},
      not_good: %{name: "Error me out", action: fn _, _ -> {:error, "Expected error"} end}
    ]
end

defp change_price(products, params) do
    new_price = Map.get(params, "new_price") |> Decimal.new()

    Enum.map(products, fn p ->
      Ecto.Changeset.change(p, %{price: new_price})
      |> Bakery.Repo.update()
    end)

    :ok
end
```

![Screen Shot 2020-06-21 at 19 36 49](https://user-images.githubusercontent.com/602354/85230173-15aa5580-b3f7-11ea-8b98-8f1b81ae404f.png)

![Screen Shot 2020-06-21 at 19 37 39](https://user-images.githubusercontent.com/602354/85230175-1cd16380-b3f7-11ea-9835-3bb59da264f8.png)
