### PR TITLE
[fix](form) add inlines error validations

### DIFF
--- a/lib/kaffy/resource_error.ex
+++ b/lib/kaffy/resource_error.ex
@@ -1,14 +1,25 @@
 defmodule Kaffy.ResourceError do
   use Phoenix.HTML
 
-  def display_errors(form) do
+  def form_error_border_class(form, default_class) do
+    if Enum.count(form.errors) > 0 do
+      "border-left-danger"
+    else
+      default_class
+    end
+  end
+
+  def display_errors(conn, form) do
     errors =
       case length(form.errors) do
         0 ->
           []
 
         _x ->
-          keys = Keyword.keys(form.errors) |> Enum.uniq()
+          keys =
+            Keyword.keys(form.errors)
+            |> Enum.uniq()
+            |> Enum.filter(fn x -> not is_field_in_form?(x, conn) end)
 
           for field <- keys,
               do:
@@ -33,5 +44,11 @@ defmodule Kaffy.ResourceError do
     Enum.reduce(errors, [], fn error, combined ->
       Enum.reduce(error, combined, fn e, all -> [e | all] end)
     end)
+  end
+
+  defp is_field_in_form?(field, conn) do
+    # check if field is part of the form, as we are showing inlines errors we don't want to show them twice.
+    # This is needed as some field error might not be inlines, for instance for a required field from changetset that's not displayed in the form
+    conn.params[conn.assigns.resource] |> Map.has_key?(Atom.to_string(field))
   end
 end

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -304,6 +304,17 @@ defmodule Kaffy.ResourceForm do
     end
   end
 
+  def get_field_error(form, field) do
+    case Keyword.get_values(form.errors, field) do
+      [{msg, _}] ->
+        error_msg = Kaffy.ResourceAdmin.humanize_term(field) <> " " <> msg <> "!"
+        {error_msg, "is-invalid"}
+
+      _ ->
+        {nil, ""}
+    end
+  end
+
   def kaffy_input(conn, changeset, form, field, options) do
     ft = Kaffy.ResourceSchema.field_type(changeset.data.__struct__, field)
 
@@ -312,13 +323,23 @@ defmodule Kaffy.ResourceForm do
         ft.render_form(conn, changeset, form, field, options)
 
       false ->
-        content_tag :div, class: "form-group" do
+        {error_msg, error_class} = get_field_error(form, field)
+
+        content_tag :div, class: "form-group #{error_class}" do
           label_tag = if ft != :boolean, do: form_label(form, {field, options}), else: ""
 
           field_tag =
-            form_field(changeset, form, {field, options}, class: "form-control", conn: conn)
+            form_field(changeset, form, {field, options},
+              class: "form-control #{error_class}",
+              conn: conn
+            )
 
-          [label_tag, field_tag]
+          field_feeback =
+            content_tag :div, class: "invalid-feedback" do
+              error_msg
+            end
+
+          [label_tag, field_tag, field_feeback]
         end
     end
   end

--- a/lib/kaffy_web/templates/resource/new.html.eex
+++ b/lib/kaffy_web/templates/resource/new.html.eex
@@ -1,10 +1,11 @@
 
-<%= for error <- Kaffy.ResourceError.display_errors(@changeset) do %>
+<%= for error <- Kaffy.ResourceError.display_errors(@conn, @changeset) do %>
 <div><%= error %></div>
 <% end %>
 
+
 <div class="mt-3 grid-margin stretch-card">
-    <div class="card shadow border-left-primary">
+    <div class="card shadow <%= Kaffy.ResourceError.form_error_border_class(@changeset, "border-left-primary")%>">
         <div class="card-header">
             <div class="row justify-content-between">
                 <div class="col-auto mr-auto">

--- a/lib/kaffy_web/templates/resource/show.html.eex
+++ b/lib/kaffy_web/templates/resource/show.html.eex
@@ -1,11 +1,11 @@
 
 
-<%= for error <- Kaffy.ResourceError.display_errors(@changeset) do %>
+<%= for error <- Kaffy.ResourceError.display_errors(@conn, @changeset) do %>
     <div><%= error %></div>
 <% end %>
 
 <div class="mt-3 grid-margin stretch-card">
-    <div class="card shadow border-left-success">
+    <div class="card shadow <%= Kaffy.ResourceError.form_error_border_class(@changeset, "border-left-success")%>">
         <div class="card-header">
             <div class="row justify-content-between">
                 <div class="col-auto mr-auto">


### PR DESCRIPTION
Here a PR to display inlines the error in the form.

This might needs more eyes:
![image](https://user-images.githubusercontent.com/53455/85414979-14029e00-b56d-11ea-860b-608c594f7415.png)

I purposely removed the error from the top, as it can stack up a lot of message and it wasn't very elegant.

Let me know what you think!