### PR TITLE
[fix](ordering) fix ordering display when defining own ordering

### DIFF
--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -9,15 +9,7 @@ defmodule Kaffy.ResourceQuery do
     search = Map.get(params, "search", "") |> String.trim()
     search_fields = Kaffy.ResourceAdmin.search_fields(resource)
     filtered_fields = get_filter_fields(params, resource)
-    default_ordering = Kaffy.ResourceAdmin.ordering(resource)
-    default_order_field = Map.get(params, "_of", "nil") |> String.to_existing_atom()
-    default_order_way = Map.get(params, "_ow", "nil") |> String.to_existing_atom()
-
-    ordering =
-      case is_nil(default_order_field) or is_nil(default_order_way) do
-        true -> default_ordering
-        false -> [{default_order_way, default_order_field}]
-      end
+    ordering = get_ordering(resource, params)
 
     current_offset = (page - 1) * per_page
     schema = resource[:schema]
@@ -38,6 +30,17 @@ defmodule Kaffy.ResourceQuery do
     do_cache = if search == "" and Enum.empty?(filtered_fields), do: true, else: false
     all_count = cached_total_count(schema, do_cache, all)
     {all_count, current_page}
+  end
+
+  def get_ordering(resource, params) do
+    default_ordering = Kaffy.ResourceAdmin.ordering(resource)
+    default_order_field = Map.get(params, "_of", "nil") |> String.to_existing_atom()
+    default_order_way = Map.get(params, "_ow", "nil") |> String.to_existing_atom()
+
+    case is_nil(default_order_field) or is_nil(default_order_way) do
+      true -> default_ordering
+      false -> [{default_order_way, default_order_field}]
+    end
   end
 
   def fetch_resource(resource, id) do

--- a/lib/kaffy_web/templates/resource/_table_header.html.eex
+++ b/lib/kaffy_web/templates/resource/_table_header.html.eex
@@ -7,11 +7,11 @@
     </th>
     <%= for field <- @fields do %>
         <% field_name = Kaffy.ResourceSchema.kaffy_field_name(@my_resource[:schema], field) |> String.upcase() %>
-        <% order_field = Map.get(@params, "_of", "id") %>
-        <% order_way = Map.get(@params, "_ow", "desc") %>
+        <% [{order_way, order_field}] = Kaffy.ResourceQuery.get_ordering(@my_resource, @params) %>
+
         <th>
-            <%= if order_field == (elem(field, 0) |> to_string()) do %>
-                <a name="<%= field_name %>" class="kaffy-order-field" data-order="<%= if order_way == "desc" do %>asc<% else %>desc<% end %>" data-field="<%= elem(field, 0) %>"><%= field_name %> <i class="fas fa-<%= if order_way == "desc" do %>arrow-down<% else %>arrow-up<% end %>"></i><a>
+            <%= if order_field == elem(field, 0) do %>
+                <a name="<%= field_name %>" class="kaffy-order-field" data-order="<%= if order_way == :desc do %>asc<% else %>desc<% end %>" data-field="<%= elem(field, 0) %>"><%= field_name %> <i class="fas fa-<%= if order_way == :desc do %>arrow-down<% else %>arrow-up<% end %>"></i><a>
             <% else %>
                 <a name="<%= field_name %>" class="kaffy-order-field" data-order="asc" data-field="<%= elem(field, 0) %>"><%= field_name %><a>
             <% end %>


### PR DESCRIPTION
**Issue on master:**
When defining your own ordering, the index page is not displaying the current ordering properly as it only use the params for this.

This PR solves this.
