### PR TITLE
Fix delete_callback handler

### DIFF
--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -305,7 +305,7 @@ defmodule KaffyWeb.ResourceController do
             )
             |> redirect_to_resource(context, resource, entry)
 
-          {:error, {entry, error}} when is_binary(error) ->
+          {:error, {_entry, error}} when is_binary(error) ->
             put_flash(conn, :error, error)
             |> redirect_to_resource(context, resource, entry)
         end


### PR DESCRIPTION
## Motivation

Delete callback handler is handing a Changeset to `redirect_to_resource/3` as `entry`, but it expected a schema.

## Proposed solution

Hands entry as defined by `Kaffy.ResourceQuery.fetch_resource/3`.