### PR TITLE
Handle binary_ids and schema without strings.

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -107,6 +107,12 @@ defmodule Kaffy.ResourceForm do
           false -> text_or_assoc(conn, schema, form, field, opts)
         end
 
+      :binary_id ->
+        case Kaffy.ResourceSchema.primary_key(schema) == [field] do
+          true -> text_input(form, field, opts)
+          false -> text_or_assoc(conn, schema, form, field, opts)
+        end
+
       :string ->
         text_input(form, field, opts)
 
@@ -304,7 +310,7 @@ defmodule Kaffy.ResourceForm do
 
             string_field =
               case is_nil(popular_strings) do
-                true -> Enum.at(string_fields, 0) |> elem(0)
+                true -> (Enum.at(string_fields, 0) || {:id}) |> elem(0)
                 false -> elem(popular_strings, 0)
               end
 


### PR DESCRIPTION
Fixes: #146

If you are using binary_ids in your schema the current setup turns them into strings (the default case) in `Kaffy.ResourceForm ` which prevents loading of belongs_to select options.

Also, in you have a schema without a string, there's an error when hitting the show controller function because there's no option to handle a case without any strings in a schema.

This PR fixes both issues.