### PR TITLE
Add support for custom logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Otherwise, if you'd like to explicitly specify your schemas and their admin modu
 # config.exs
 config :kaffy,
   admin_title: "My Awesome App",
+  admin_logo: "/images/logo.png",
+  admin_logo_mini: "/images/logo-mini.png",
   hide_dashboard: false,
   home_page: [kaffy: :dashboard],
   ecto_repo: MyApp.Repo,

--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -10,6 +10,22 @@ defmodule Kaffy.Utils do
   end
 
   @doc """
+  Returns the :admin_logo config if present, otherwise returns Kaffy default logo.
+  """
+  @spec logo(Plug.Conn.t()) :: String.t()
+  def logo(conn) do
+    router().static_path(conn, env(:admin_logo, "/kaffy/assets/images/logo.png"))
+  end
+
+  @doc """
+  Returns the :admin_logo_mini config if present, otherwise returns Kaffy default logo.
+  """
+  @spec logo_mini(Plug.Conn.t()) :: String.t()
+  def logo_mini(conn) do
+    router().static_path(conn, env(:admin_logo_mini, "/kaffy/assets/images/logo-mini.png"))
+  end
+
+  @doc """
   Returns the JSON package used by phoenix configs. If no such config exists, raise an exception.
   """
   @spec json() :: atom()

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -20,10 +20,10 @@
       <nav class="navbar default-layout-navbar col-lg-12 col-12 p-0 fixed-top d-flex flex-row">
         <div class="text-center navbar-brand-wrapper d-flex align-items-center justify-content-center">
           <%= link to: Kaffy.Utils.router().kaffy_home_path(@conn, :index), class: "navbar-brand brand-logo" do %>
-            <img src="/kaffy/assets/images/logo.png" alt="logo" />
+            <img src="<%= Kaffy.Utils.logo(@conn) %>" alt="logo" />
           <% end %>
           <%= link to: Kaffy.Utils.router().kaffy_home_path(@conn, :index), class: "navbar-brand brand-logo-mini" do %>
-            <img src="/kaffy/assets/images/logo-mini.png" alt="logo" />
+            <img src="<%= Kaffy.Utils.logo_mini(@conn) %>"  alt="logo" />
           <% end %>
         </div>
         <div class="navbar-menu-wrapper d-flex align-items-stretch">


### PR DESCRIPTION
Not sure if this feature have been discussed. But here is a pull requests that allows for custom logos.

The rational being, that while the develop understands what Kaffy is, the administrators who are actually using the administration panel might not have the slightest clue.

Hopefully it can be used. :-)