### PR TITLE
Never do a search, if search string is empty

### DIFF
--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -102,7 +102,7 @@ defmodule Kaffy.ResourceQuery do
 
     query =
       cond do
-        (is_nil(search_fields) || Enum.empty?(search_fields)) && search == "" ->
+        (is_nil(search_fields) || Enum.empty?(search_fields)) || search == "" ->
           query
 
         true ->


### PR DESCRIPTION
Hello,

I recently encountered a bug, where the index page would state no entries even thought not true.

I have the following wallet structure.

```
  schema "wallets" do
    field :balance, :decimal
    field :device_id, :string
    has_many :transactions, Transaction

    timestamps()
  end
```

The device is not required, but Kaffy will automatically add it to [search_fields](https://github.com/aesmail/kaffy/blob/master/lib/kaffy/resource_query.ex#L10) which makes good sense. But if i create a new a new wallet with no device_id, this [line](https://github.com/aesmail/kaffy/blob/master/lib/kaffy/resource_query.ex#L105) will always return false, adding a filter which doesn't match.

As search_fields is neither nil or empty, it contains :device_id, and since no search was given it defaults to "", hence. line will be false.
Instead it should always result in true if the search string is empty.

Currently this happens.

![kaffy](https://user-images.githubusercontent.com/1180266/94257864-3e794400-ff2c-11ea-93cd-5283c00c7894.png)



 