### PR TITLE
Allow pass opts to Repo in custom_index_query and custom_show_query callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,19 @@ It is called when fetching the resources for the index page.
 
 The `custom_show_query/3` is identifical to `custom_index_query/3`, but works when fetching a single resource in the show/edit page.
 
+It's also possible to pass `opts` to the Repo operation, in this case, you just have to return a tuple instead, like below:
+
+```elixir
+defmodule MyApp.Accounts.TenantAdmin do
+  def custom_index_query(_conn, _schema, query) do
+    {query, skip_tenant_id: true}
+  end
+
+  def custom_show_query(_conn, _schema, query) do
+    {query, skip_tenant_id: true}
+  end
+end
+```
 
 ### Extensions
 

--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -25,11 +25,17 @@ defmodule Kaffy.ResourceQuery do
         current_offset
       )
 
-    custom_query = Kaffy.ResourceAdmin.custom_index_query(conn, resource, paged)
-    current_page = Kaffy.Utils.repo().all(custom_query)
+    {current_page, opts} =
+      case Kaffy.ResourceAdmin.custom_index_query(conn, resource, paged) do
+        {custom_query, opts} ->
+          {Kaffy.Utils.repo().all(custom_query, opts), opts}
+
+        custom_query ->
+          {Kaffy.Utils.repo().all(custom_query), []}
+      end
 
     do_cache = if search == "" and Enum.empty?(filtered_fields), do: true, else: false
-    all_count = cached_total_count(schema, do_cache, all)
+    all_count = cached_total_count(schema, do_cache, all, opts)
     {all_count, current_page}
   end
 
@@ -47,8 +53,11 @@ defmodule Kaffy.ResourceQuery do
   def fetch_resource(conn, resource, id) do
     schema = resource[:schema]
     query = from(s in schema, where: s.id == ^id)
-    custom_query = Kaffy.ResourceAdmin.custom_show_query(conn, resource, query)
-    Kaffy.Utils.repo().one(custom_query)
+
+    case Kaffy.ResourceAdmin.custom_show_query(conn, resource, query) do
+      {custom_query, opts} -> Kaffy.Utils.repo().one(custom_query, opts)
+      custom_query -> Kaffy.Utils.repo().one(custom_query)
+    end
   end
 
   def fetch_list(_, [""]), do: []
@@ -60,10 +69,12 @@ defmodule Kaffy.ResourceQuery do
     |> Kaffy.Utils.repo().all()
   end
 
-  def total_count(schema, do_cache, query) do
+  def total_count(schema, do_cache, query, opts \\ [])
+
+  def total_count(schema, do_cache, query, opts) do
     result =
       from(s in query, select: fragment("count(*)"))
-      |> Kaffy.Utils.repo().one()
+      |> Kaffy.Utils.repo().one(opts)
 
     if do_cache and result > 100_000 do
       Kaffy.Cache.Client.add_cache(schema, "count", result, 600)
@@ -72,10 +83,12 @@ defmodule Kaffy.ResourceQuery do
     result
   end
 
-  def cached_total_count(schema, false, query), do: total_count(schema, false, query)
+  def cached_total_count(schema, do_cache, query, opts \\ [])
 
-  def cached_total_count(schema, do_cache, query) do
-    Kaffy.Cache.Client.get_cache(schema, "count") || total_count(schema, do_cache, query)
+  def cached_total_count(schema, false, query, opts), do: total_count(schema, false, query, opts)
+
+  def cached_total_count(schema, do_cache, query, opts) do
+    Kaffy.Cache.Client.get_cache(schema, "count") || total_count(schema, do_cache, query, opts)
   end
 
   defp get_filter_fields(params, resource) do


### PR DESCRIPTION
I'm building an app that uses foreign key strategy to implement multi-tenants, identical to the example presented in Ecto Guides (https://hexdocs.pm/ecto/multi-tenancy-with-foreign-keys.html). 

To make this possible, I need to pass options to Repo. Like the example shown on Ecto guide:

```elixir
MyApp.Repo.all(Tenant, skip_tenant_id: true)
```

Kaffy does not support passing `opts` to `Repo` from `custom_index_query` and `custom_show_query`. The purpose of this pull request is to eliminate this limitation, without introducing breaking changes.

```elixir
# Introduced by this pull request
defmodule MyApp.Accounts.TenantAdmin do
  def custom_index_query(_conn, _schema, query) do
    {query, skip_tenant_id: true}
  end
end

# It's still support the old way
defmodule MyApp.Blog.PostAdmin do
  def custom_index_query(_conn, _schema, query) do
    from(r in query, preload: [:tags])
  end
end
```