### PR TITLE
Adds multitenancy support

### DIFF
--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -5,7 +5,7 @@ defmodule Kaffy.ResourceCallbacks do
 
   def create_callbacks(conn, resource, changes) do
     changeset = Kaffy.ResourceAdmin.create_changeset(resource, changes)
-    repo = Kaffy.Utils.repo()
+    repo = Kaffy.Utils.repo(resource)
 
     repo.transaction(fn ->
       result =
@@ -28,7 +28,7 @@ defmodule Kaffy.ResourceCallbacks do
       {:ok, entry}
     else
       {:error, :not_found} ->
-        Kaffy.Utils.repo().insert(changeset)
+        Kaffy.Utils.repo(resource).insert(changeset)
 
       unexpected_error ->
         {:error, unexpected_error}
@@ -37,7 +37,7 @@ defmodule Kaffy.ResourceCallbacks do
 
   def update_callbacks(conn, resource, entry, changes) do
     changeset = Kaffy.ResourceAdmin.update_changeset(resource, entry, changes)
-    repo = Kaffy.Utils.repo()
+    repo = Kaffy.Utils.repo(resource)
 
     repo.transaction(fn ->
       result =
@@ -60,7 +60,7 @@ defmodule Kaffy.ResourceCallbacks do
       {:ok, entry}
     else
       {:error, :not_found} ->
-        Kaffy.Utils.repo().update(changeset)
+        Kaffy.Utils.repo(resource).update(changeset)
 
       unexpected_error ->
         {:error, unexpected_error}
@@ -68,7 +68,7 @@ defmodule Kaffy.ResourceCallbacks do
   end
 
   def delete_callbacks(conn, resource, entry) do
-    repo = Kaffy.Utils.repo()
+    repo = Kaffy.Utils.repo(resource)
 
     repo.transaction(fn ->
       result =
@@ -163,7 +163,7 @@ defmodule Kaffy.ResourceCallbacks do
       {:ok, entry}
     else
       {:error, :not_found} ->
-        Kaffy.Utils.repo().delete(changeset)
+        Kaffy.Utils.repo(resource).delete(changeset)
 
       unexpected_error ->
         {:error, unexpected_error}

--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -51,6 +51,14 @@ defmodule Kaffy.Utils do
   end
 
   @doc """
+  Returns the repo module specified by the resource
+  """
+  @spec repo(String.t()) :: atom()
+  def repo(resource) do
+    resource[:repo] || repo()
+  end
+
+  @doc """
   Returns the version of the provided app.
 
   Example:
@@ -118,6 +126,14 @@ defmodule Kaffy.Utils do
       f when is_function(f) -> f.(conn)
       l when is_list(l) -> l
       _ -> setup_resources()
+    end
+  end
+
+  @spec full_resources(Plug.Conn.t()) :: atom() | pid() | nil
+  def set_dynamic_repo(conn) do
+    case env(:set_dynamic_repo) do
+      f when is_function(f) -> f.(conn)
+      _ -> nil
     end
   end
 
@@ -340,7 +356,15 @@ defmodule Kaffy.Utils do
         end
       end)
 
-    %{stylesheets: stylesheets, javascripts: javascripts}
+    navigation_extras =
+      Enum.map(exts, fn ext ->
+        case function_exported?(ext, :navigation_extras, 1) do
+          true -> ext.navigation_extras(conn)
+          false -> []
+        end
+      end)
+
+    %{stylesheets: stylesheets, javascripts: javascripts, navigation_extras: navigation_extras}
   end
 
   defp env(key, default \\ nil) do

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -15,6 +15,7 @@ defmodule KaffyWeb.ResourceController do
           "pick" => _field
         } = params
       ) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
 
     case can_proceed?(my_resource, conn) do
@@ -52,6 +53,7 @@ defmodule KaffyWeb.ResourceController do
   end
 
   def index(conn, %{"context" => context, "resource" => resource} = params) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
 
     case can_proceed?(my_resource, conn) do
@@ -89,6 +91,7 @@ defmodule KaffyWeb.ResourceController do
   end
 
   def show(conn, %{"context" => context, "resource" => resource, "id" => id}) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     schema = my_resource[:schema]
     resource_name = Kaffy.ResourceAdmin.singular_name(my_resource)
@@ -121,6 +124,7 @@ defmodule KaffyWeb.ResourceController do
   end
 
   def update(conn, %{"context" => context, "resource" => resource, "id" => id} = params) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     schema = my_resource[:schema]
     params = Kaffy.ResourceParams.decode_map_fields(resource, schema, params)
@@ -200,6 +204,7 @@ defmodule KaffyWeb.ResourceController do
   end
 
   def new(conn, %{"context" => context, "resource" => resource}) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     resource_name = Kaffy.ResourceAdmin.singular_name(my_resource)
 
@@ -222,6 +227,7 @@ defmodule KaffyWeb.ResourceController do
   end
 
   def create(conn, %{"context" => context, "resource" => resource} = params) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     params = Kaffy.ResourceParams.decode_map_fields(resource, my_resource[:schema], params)
     changes = Map.get(params, resource, %{})
@@ -281,6 +287,7 @@ defmodule KaffyWeb.ResourceController do
   end
 
   def delete(conn, %{"context" => context, "resource" => resource, "id" => id}) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
 
     case can_proceed?(my_resource, conn) do
@@ -318,6 +325,7 @@ defmodule KaffyWeb.ResourceController do
         "id" => id,
         "action_key" => action_key
       }) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     entry = Kaffy.ResourceQuery.fetch_resource(conn, my_resource, id)
     actions = Kaffy.ResourceAdmin.resource_actions(my_resource, conn)
@@ -342,6 +350,7 @@ defmodule KaffyWeb.ResourceController do
         conn,
         %{"context" => context, "resource" => resource, "action_key" => action_key} = params
       ) do
+    Kaffy.Utils.set_dynamic_repo(conn)
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     ids = Map.get(params, "ids", "") |> String.split(",")
     entries = Kaffy.ResourceQuery.fetch_list(my_resource, ids)

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -26,7 +26,7 @@
             <img src="<%= Kaffy.Utils.logo_mini(@conn) %>"  alt="logo" />
           <% end %>
         </div>
-        <div class="navbar-menu-wrapper d-flex align-items-stretch">
+        <div class="navbar-menu-wrapper d-flex align-items-stretch justify-content-between">
           <button class="navbar-toggler navbar-toggler align-self-center" type="button" data-toggle="minimize">
             <span class="fas fa-bars"></span>
           </button>
@@ -34,6 +34,10 @@
           <button class="navbar-toggler navbar-toggler-right d-lg-none align-self-center" type="button" data-toggle="offcanvas">
             <span class="fas fa-bars"></span>
           </button>
+
+          <%= for extra <- Kaffy.Utils.extensions(@conn).navigation_extras do %>
+            <%= extra %>
+          <% end %>
         </div>
       </nav>
 

--- a/lib/kaffy_web/templates/resource/new.html.eex
+++ b/lib/kaffy_web/templates/resource/new.html.eex
@@ -17,7 +17,7 @@
             <%= f = form_for(@changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :create, @context, @resource), method: :post, multipart: true) %>
                 <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
                     <%= if options.create != :hidden do %>
-                        <%= Kaffy.ResourceForm.kaffy_input @conn, @changeset, f, field, options %>
+                        <%= Kaffy.ResourceForm.kaffy_input @conn, @my_resource, @changeset, f, field, options %>
                     <% end %>
                 <% end %>
                 <div class="form-group">

--- a/lib/kaffy_web/templates/resource/show.html.eex
+++ b/lib/kaffy_web/templates/resource/show.html.eex
@@ -35,7 +35,7 @@
             <%= f = form_for(@changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :update, @context, @resource, @changeset.data.id), method: :put, multipart: true) %>
                 <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
                     <%= if options.update != :hidden do %>
-                        <%= Kaffy.ResourceForm.kaffy_input @conn, @changeset, f, field, options %>
+                        <%= Kaffy.ResourceForm.kaffy_input @conn, @my_resource, @changeset, f, field, options %>
                     <% end %>
                 <% end %>
 


### PR DESCRIPTION
Why:

* When building an admin dashboard is not always true that:

  1. There is only one repo
  2. The repo is not dynamic

This change addresses the need by:

* Adding a resource level repo config that can be set when creating the
  resources list, to allow for multiple repos. It defaults to the ecto
  repo config in the env.
* Adding a new configurable function called `set_dynamic_repo`, which
  takes the connection as based on that it will set the dynamic repo.
  Since the dynamic repo is set per process, this is done on every
  controller action, so that we can ensure it is set properly. An
  example of this could be by setting a cookie with the tenant, which a
  plug can assign to the connection and have the `set_dynamic_repo` use
  that to decide what to do.
* Adding a new form of extension called navigation extras, which allows
  adding html to the top navigation. This can be used by, for example,
  having a select with the multiple tenants

This changes quite a few things and I don't expect you to agree with all the decisions, but it should allow us to get the conversation going at least. I'm not super familiar with kaffy's codebase, but I tried to leverage as much of the existing API as possible and ensure that no existing configuration need to change.