### PR TITLE
let specify the full 'path' for FontAwesome fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Widgets have shared options:
 - `:order` (optional) is the displaying order of the widget. Widgets are display in order based on this value. The default value is 999.
 - `:width` (optional) is the width the widget should occupy on the page. Valid values are 1 to 12. The default for tidbits is 3 and the others 6.
 - `:percentage` (required for progress widgets) is the percentage value for the progress. This must be an integer.
-- `:icon` (optional for tidbit widgets) is the icon displayed next to the tidbit's `content`. Any FontAwesome-valid icon is valid here. For example: `thumbs-up`.
+- `:full_icon` (optional for tidbit widgets) is the icon displayed next to the tidbit's `content`. You have to specify the full name given by FontAwesome like `fas fa-thumbs-up`.
+- `:icon` (optional for tidbit widgets) is the icon displayed next to the tidbit's `content`. Any FontAwesome-valid icon is valid here. For example: `thumbs-up`. But it's limited to the `fas` group. For full defintion see `:full_icon`.
 
 When defining a chart widget, the content must be a map with the following required keys:
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Use Jason for JSON parsing in Phoenix
 # config :phoenix, :json_library, Jason

--- a/lib/kaffy.ex
+++ b/lib/kaffy.ex
@@ -1,7 +1,0 @@
-defmodule Kaffy do
-  @moduledoc false
-
-  def hello do
-    :world
-  end
-end

--- a/lib/kaffy/routes.ex
+++ b/lib/kaffy/routes.ex
@@ -25,6 +25,7 @@ defmodule Kaffy.Routes do
         plug(:fetch_flash)
         plug(:protect_from_forgery)
         plug(:put_secure_browser_headers)
+        plug(:put_root_layout, {KaffyWeb.LayoutView, :root})
       end
 
       scope unquote(scoped), KaffyWeb do

--- a/lib/kaffy_web/templates/home/_card.html.eex
+++ b/lib/kaffy_web/templates/home/_card.html.eex
@@ -2,7 +2,7 @@
     <div class="card bg-<%= @widget.type %> card-img-holder text-white">
         <div class="card-body">
             <img src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/images/dashboard/circle.svg") %>" class="card-img-absolute" alt="circle-image" />
-            <h4 class="font-weight-normal mb-3"><%= @widget.title %> <i class="fas fa-<%= @widget.icon %> float-right"></i></h4>
+            <h4 class="font-weight-normal mb-3"><%= @widget.title %> <i class="<%= if @widget[:full_icon] do %><%= @widget.full_icon %><% else %>fas fa-<%= @widget.icon %><% end %> float-right"></i></h4>
             <h2 class="mb-5"><%= @widget.content %></h2>
             <h6 class="card-text"><%= @widget.subcontent %></h6>
         </div>

--- a/lib/kaffy_web/templates/home/_tidbit.html.eex
+++ b/lib/kaffy_web/templates/home/_tidbit.html.eex
@@ -1,7 +1,7 @@
 <div class="col-md-<%= @widget.width %> grid-margin stretch-card">
     <div class="card shadow border-left-success">
         <div class="card-body">
-            <p class="font-weight-normal mb-1 text-success"><strong><%= @widget.title %></strong> <i class="fa fa-<%= @widget.icon %> float-right"></i></p>
+            <p class="font-weight-normal mb-1 text-success"><strong><%= @widget.title %></strong> <i class="<%= if @widget[:full_icon] do %><%= @widget.full_icon %><% else %>fas fa-<%= @widget.icon %><% end %> float-right"></i></p>
             <h2 class="mt-1"><%= @widget.content %></h2>
         </div>
     </div>

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -65,7 +65,7 @@
               <li class="nav-item">
                 <%= link to: custom_link.url, method: custom_link.method, class: "nav-link", target: custom_link.target do %>
                   <span class="menu-title"><%= custom_link.name %></span>
-                  <i class="fas fa-<%= custom_link.icon %> menu-icon"></i>
+                  <i class="<%= if custom_link.full_icon do %><%= custom_link[:full_icon] %><% else %>fas fa-<%= custom_link.icon %><% end %> menu-icon"></i>
                 <% end %>
               </li>
             <% end %>

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -65,7 +65,7 @@
               <li class="nav-item">
                 <%= link to: custom_link.url, method: custom_link.method, class: "nav-link", target: custom_link.target do %>
                   <span class="menu-title"><%= custom_link.name %></span>
-                  <i class="<%= if custom_link.full_icon do %><%= custom_link[:full_icon] %><% else %>fas fa-<%= custom_link.icon %><% end %> menu-icon"></i>
+                  <i class="<%= if custom_link.full_icon do %><%= custom_link.full_icon %><% else %>fas fa-<%= custom_link.icon %><% end %> menu-icon"></i>
                 <% end %>
               </li>
             <% end %>

--- a/lib/kaffy_web/templates/layout/root.html.eex
+++ b/lib/kaffy_web/templates/layout/root.html.eex
@@ -1,0 +1,1 @@
+<%= @inner_content %>

--- a/test/kaffy_test.exs
+++ b/test/kaffy_test.exs
@@ -1,12 +1,7 @@
 defmodule KaffyTest do
   use ExUnit.Case
-  doctest Kaffy
   alias KaffyTest.Schemas.{Company, Person, Pet}
   # alias KaffyTest.Admin.PersonAdmin
-
-  test "greets the world" do
-    assert Kaffy.hello() == :world
-  end
 
   test "creating a person" do
     person = %Person{}


### PR DESCRIPTION
Because FontAwesome is using different prefixes (https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use): fas, fab, far, fad and fal; I've made an addition to the specification for tidbit and widgets to let us use `full_icon` and specify, i.e. `fab fa-google-play` 