### PR TITLE
Add basic support for enums

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -172,6 +172,18 @@ defmodule Kaffy.ResourceForm do
 
         textarea(form, field, [value: value, rows: 4, placeholder: "JSON Content"] ++ opts)
 
+      {:parameterized, Ecto.Enum, %{values: values}} ->
+        values = Enum.map(values, &to_string/1)
+        value = Map.get(data, field, nil)
+
+        select(form, field, values, [value: value] ++ opts)
+
+      {:array, {:parameterized, Ecto.Enum, %{values: values}}} ->
+        values = Enum.map(values, &to_string/1)
+        value = Map.get(data, field, nil)
+
+        multiple_select(form, field, values, [value: value] ++ opts)
+
       {:array, _} ->
         value =
           data

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -210,6 +210,9 @@ defmodule Kaffy.ResourceSchema do
       is_binary(value) ->
         String.slice(value, 0, 140)
 
+      is_list(value) ->
+        pretty_list(value)
+
       true ->
         value
     end
@@ -312,4 +315,11 @@ defmodule Kaffy.ResourceSchema do
   def widgets(_resource) do
     []
   end
+
+  defp pretty_list([]), do: ""
+  defp pretty_list([item]), do: to_string(item)
+  defp pretty_list([a, b]), do: "#{a} and #{b}"
+  defp pretty_list([a, b, c]), do: "#{a}, #{b} and #{c}"
+  defp pretty_list([a, b, c, d]), do: "#{a}, #{b}, #{c} and #{d}"
+  defp pretty_list([a, b, c | rest]), do: "#{a}, #{b}, #{c} and #{length(rest)} others..."
 end


### PR DESCRIPTION
This adds support for the new `Ecto.Enum` type, as well as the array version. I checked a bit and didn't find any special arangements regarding multiple selects, so I'd like to know, if it would be a good idea to add [chosen-js](https://harvesthq.github.io/chosen/#multiple-select) as well.