### PR TITLE
Config assets to use static path

### DIFF
--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -10,6 +10,14 @@ defmodule Kaffy.Utils do
   end
 
   @doc """
+  Returns the static path to the asset.
+  """
+  @spec static_asset_path(Plug.Conn.t(), String.t()) :: String.t()
+  def static_asset_path(conn, asset_path) do
+    router().static_path(conn, asset_path)
+  end
+
+  @doc """
   Returns the :admin_logo config if present, otherwise returns Kaffy default logo.
   """
   @spec logo(Plug.Conn.t()) :: String.t()

--- a/lib/kaffy_web/templates/home/_card.html.eex
+++ b/lib/kaffy_web/templates/home/_card.html.eex
@@ -1,7 +1,7 @@
 <div class="col-md-<%= @widget.width %> stretch-card grid-margin">
     <div class="card bg-<%= @widget.type %> card-img-holder text-white">
         <div class="card-body">
-            <img src="/kaffy/assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" />
+            <img src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/images/dashboard/circle.svg") %>" class="card-img-absolute" alt="circle-image" />
             <h4 class="font-weight-normal mb-3"><%= @widget.title %> <i class="fas fa-<%= @widget.icon %> float-right"></i></h4>
             <h2 class="mb-5"><%= @widget.content %></h2>
             <h6 class="card-text"><%= @widget.subcontent %></h6>

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -4,16 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= Kaffy.Utils.title() %> - Kaffy</title>
-    <link rel="stylesheet" href="/kaffy/assets/vendors/fontawesome/css/all.css">
-    <link rel="stylesheet" href="/kaffy/assets/vendors/css/vendor.bundle.base.css">
-    <link rel="stylesheet" href="/kaffy/assets/scss/style.css">
-    <link rel="stylesheet" href="/kaffy/assets/vendors/flatpickr/flatpickr.min.css">
-    <link rel="stylesheet" href="/kaffy/assets/css/kaffy.css">
-    <link rel="shortcut icon" href="/kaffy/assets/images/favicon/favicon-32x32.png" />
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/fontawesome/css/all.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/css/vendor.bundle.base.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/scss/style.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/flatpickr/flatpickr.min.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/css/kaffy.css") %>">
+    <link rel="shortcut icon" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/images/favicon/favicon-32x32.png") %>" />
     <%= for css <- Kaffy.Utils.extensions(@conn).stylesheets do %>
       <%= css %>
     <% end %>
-    <script src="/kaffy/assets/vendors/js/vendor.bundle.base.js"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/js/vendor.bundle.base.js") %>"></script>
   </head>
   <body>
     <div class="container-scroller">
@@ -154,15 +154,15 @@
       </div>
     </div>
 
-    <script src="/kaffy/assets/vendors/flatpickr/flatpickr.min.js"></script>
-    <script src="/kaffy/assets/vendors/chart.js/Chart.min.js"></script>
-    <script src="/kaffy/assets/vendors/js/ckeditor.js"></script>
-    <script src="/kaffy/assets/js/off-canvas.js"></script>
-    <script src="/kaffy/assets/js/hoverable-collapse.js"></script>
-    <script src="/kaffy/assets/js/misc.js"></script>
-    <script src="/kaffy/assets/js/select-all-checkbox.js?v=20"></script>
-    <script src="/kaffy/assets/js/phoenix_html.js"></script>
-    <script src="/kaffy/assets/js/dashboard.js?v=20"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/flatpickr/flatpickr.min.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/chart.js/Chart.min.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/js/ckeditor.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/off-canvas.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/hoverable-collapse.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/misc.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/select-all-checkbox.js?v=20") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/phoenix_html.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/dashboard.js?v=20") %>"></script>
     <%= for js <- Kaffy.Utils.extensions(@conn).javascripts do %>
       <%= js %>
     <% end %>

--- a/lib/kaffy_web/templates/layout/bare.html.eex
+++ b/lib/kaffy_web/templates/layout/bare.html.eex
@@ -4,16 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= Kaffy.Utils.title() %> - Kaffy</title>
-    <link rel="stylesheet" href="/kaffy/assets/vendors/fontawesome/css/all.css">
-    <link rel="stylesheet" href="/kaffy/assets/vendors/css/vendor.bundle.base.css">
-    <link rel="stylesheet" href="/kaffy/assets/scss/style.css">
-    <link rel="stylesheet" href="/kaffy/assets/vendors/flatpickr/flatpickr.min.css">
-    <link rel="stylesheet" href="/kaffy/assets/css/kaffy.css">
-    <link rel="shortcut icon" href="/kaffy/assets/images/favicon/favicon-32x32.png" />
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/fontawesome/css/all.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/css/vendor.bundle.base.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/scss/style.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/flatpickr/flatpickr.min.css") %>">
+    <link rel="stylesheet" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/css/kaffy.css") %>">
+    <link rel="shortcut icon" href="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/images/favicon/favicon-32x32.png") %>" />
     <%= for css <- Kaffy.Utils.extensions(@conn).stylesheets do %>
       <%= css %>
     <% end %>
-    <script src="/kaffy/assets/vendors/js/vendor.bundle.base.js"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/js/vendor.bundle.base.js") %>"></script>
   </head>
   <body>
     <div class="container-scroller">
@@ -57,14 +57,14 @@
       </div>
     </div>
 
-    <script src="/kaffy/assets/vendors/js/vendor.bundle.base.js"></script>
-    <script src="/kaffy/assets/vendors/flatpickr/flatpickr.min.js"></script>
-    <script src="/kaffy/assets/vendors/chart.js/Chart.min.js"></script>
-    <script src="/kaffy/assets/vendors/js/ckeditor.js"></script>
-    <script src="/kaffy/assets/js/off-canvas.js"></script>
-    <script src="/kaffy/assets/js/hoverable-collapse.js"></script>
-    <script src="/kaffy/assets/js/misc.js"></script>
-    <script src="/kaffy/assets/js/phoenix_html.js"></script>
-    <script src="/kaffy/assets/js/dashboard.js"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/js/vendor.bundle.base.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/flatpickr/flatpickr.min.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/chart.js/Chart.min.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/vendors/js/ckeditor.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/off-canvas.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/hoverable-collapse.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/misc.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/phoenix_html.js") %>"></script>
+    <script src="<%= Kaffy.Utils.static_asset_path(@conn, "/kaffy/assets/js/dashboard.js") %>"></script>
   </body>
 </html>


### PR DESCRIPTION
Right now, Kaffy assets always available at `<base_url>/kaffy`.

This might work on most of the cases but sometimes we want to also have the path customizable. This will make Kaffy more flexible. So here, we're making the Kaffy asset path available on static path. So that it is customizable from the app.

For example, in my case, I need all of assets to be under `<base_url>/my_site`. So with customizable static path, I can configure the static asset path to:

```
plug(Plug.Static,
  at: "/my_site/kaffy",
  from: :kaffy,
  gzip: false,
  only: ~w(assets)
)
```

As a result, all Kaffy assets should be loaded properly at a new custom static path.

![Screen Shot 2564-09-26 at 17 10 48](https://user-images.githubusercontent.com/6965195/134803702-390e1a1c-0fac-4bee-953c-60a9bc841420.png)

![Screen Shot 2564-09-26 at 17 30 30](https://user-images.githubusercontent.com/6965195/134804129-ad9dfb9d-42e9-4678-a3ea-bdb8cbd090cc.png)


