### PR TITLE
Decode array before adding to changeset

### DIFF
--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -301,11 +301,17 @@ defmodule Kaffy.ResourceSchema do
   def get_map_fields(schema) do
     get_all_fields(schema)
     |> Enum.filter(fn
-      {_f, options} ->
-        options.type == :map
+      {_f, %{type: :map}} ->
+        true
+
+      {_f, %{type: {:array, _}}} ->
+        true
 
       f when is_atom(f) ->
         f == :map
+
+      _ ->
+        false
     end)
   end
 


### PR DESCRIPTION
Array values are encoded before added to the form for editing but
not decoded before evaluation by the changeset. This extra formatting
causes the changeset to mark arrays as invalid with no recourse by
the user. This commit modifies `Kaffy.ResourceSchema.get_map_fields/1`
to return `{:array, _}` fields to be decoded by
`Kaffy.ResourceParams.decode_map_fields/3`. 

Fixes #130 and #184