### PR TITLE
Fix CI setup

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         otp: ['22.3']
-        elixir: ['1.7.4', '1.8.2', '1.9.4', '1.10.4', '1.11.4', '1.12.3']
+        elixir: ['1.8.2', '1.9.4', '1.10.4', '1.11.4', '1.12.3']
     
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Become a sponsor through Kaffy's [OpenCollective](https://opencollective.com/kaf
 
 ## Minimum Requirements
 
-- elixir 1.7.0
+- elixir 1.8.0
 - phoenix 1.4.0
 
 ## Installation

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Kaffy.MixProject do
     [
       app: :kaffy,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.8",
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
This commit fixes the Github Actions config to use the `setup-beam` actions package instead of `setup-elixir as suggested by Github.