### PR TITLE
Allow list actions to have select inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,10 @@ The values are maps providing a human-friendly `:name` and an `:action` that is 
 
 The `change_price` action is a multi-step action.
 The defined `:inputs` option will display a popup with a form that contains defined in this option.
-`:inputs` should be a list of maps. Each input must have a `:name`, a `:title`, and a `:default` value.
+`:inputs` should be a list of maps. Each input must have a `:name` and a `:title`.
+An optional key in the input map is `:use_select`, which defaults to `false`.
+If `true`, the input becomes a `select` instead by using a passed in list called `:options`, which is a list of lists formatted like so `[[display, value], [display, value]]`.
+If `false`, a `:default` value is required for the text input.
 After submitting the popup form, the extra values, along with the selected resources, are passed to the `:action` function.
 In the example above, `change_price/2` will receive the selected products with a map of extra inputs, like: `%{"new_price" => "3.5"}` for example.
 

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -116,8 +116,8 @@
                         <%= if Map.has_key?(extra, :use_select) && extra.use_select do %>
                           <label><%= extra.title %></label>
                           <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
-                            <%= for option <- extra.options do %>
-                              <option value="<%= Enum.at(option, 1) %>"><%= Enum.at(option, 0) %></option>
+                            <%= for [text, value] <- extra.options do %>
+                              <option value="<%= value %>"><%= text %></option>
                             <% end %>
                           </select>
                         <% else %>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -113,8 +113,17 @@
                   <div class="modal-body">
                     <%= for extra <- extra_inputs do %>
                       <div class="form-group">
-                        <label><%= extra.title %></label>
-                        <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                        <%= if Map.has_key?(extra, :use_select) && extra.use_select do %>
+                          <label><%= extra.title %></label>
+                          <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
+                            <%= for option <- extra.options do %>
+                              <option value="<%= Enum.at(option, 1) %>"><%= Enum.at(option, 0) %></option>
+                            <% end %>
+                          </select>
+                        <% else %>
+                          <label><%= extra.title %></label>
+                          <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                        <% end %>
                       </div>
                     <% end %>
                   </div>


### PR DESCRIPTION
This PR adds the option for users to use `select` inputs when creating `list_actions` on their admin pages. You could now do so by setting `:use_select` to `true` on the input and also passing in a list of `:options`. `:options` is only required if `:use_select` is `true` and `:use_select` is never required to maintain backwards compatibility. An example of a way this is useful is if we want the admins to be able to copy multiple models that contain a `body` and a `title` to a different user. Here is how that would look in the code:

```
  def list_actions(_conn) do
    options =
      Accounts.get_all_users()
      |> Enum.map(fn %{id: id, email: email} -> [email, id] end)

    [
      copy_models: %{
        name: "Copy Models",
        inputs: [
          %{name: "owner_id", title: "New Owner", use_select: true, options: options}
        ],
        action: fn _conn, models, params -> copy_models(models, params) end
      }
    ]
  end

  defp copy_models(models, %{"owner_id" => owner_id}) do
    for %{body: body, title: title} <- models do
      create_model(%{body: body, title: title, owner_id: owner_id})
    end

    :ok
  end
```