### PR TITLE
Allow deleting invalid records

### DIFF
--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -171,7 +171,8 @@ defmodule Kaffy.ResourceCallbacks do
   end
 
   defp before_delete(conn, resource, entry) do
-    changeset = Kaffy.ResourceAdmin.update_changeset(resource, entry, %{})
+    # changeset = Kaffy.ResourceAdmin.update_changeset(resource, entry, %{})
+    changeset = Ecto.Changeset.change(entry)
 
     Utils.get_assigned_value_or_default(
       resource,


### PR DESCRIPTION
This PR fixes an issue when it is not possible to delete a schema if it's not "valid".