### PR TITLE
Ensure that extension module is loaded

### DIFF
--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -334,6 +334,7 @@ defmodule Kaffy.Utils do
 
     stylesheets =
       Enum.map(exts, fn ext ->
+        Code.ensure_loaded(ext)
         case function_exported?(ext, :stylesheets, 1) do
           true -> ext.stylesheets(conn)
           false -> []
@@ -342,6 +343,7 @@ defmodule Kaffy.Utils do
 
     javascripts =
       Enum.map(exts, fn ext ->
+        Code.ensure_loaded(ext)
         case function_exported?(ext, :javascripts, 1) do
           true -> ext.javascripts(conn)
           false -> []


### PR DESCRIPTION
## Problem

In the umbrella app, the extension module may not be loaded on the server start (`mix phx.server`), so custom css and js files are not added to the DOM. However, making any change in the `MyApp.Kaffy.Extension` file in the development, loads the module and css/js files are added to the DOM. But still, on the first run or after the server restart, it doesn't load the Extension.

I debugged a local copy of Kaffy, and I found that on the first run, the following function:

``` elixir
# lib/kaffy.utils.ex - line 338
function_exported?(ext, :stylesheets, 1)
```

...gives `false`. After making any change in the `MyApp.Kaffy.Extension`, and refreshing the website to trigger new request, the above function gave me a `true`.

## Solution

Adding `Code.ensure_loaded(ext)` before `function_exported?(ext, :stylesheets, 1)` solved the issue.

## Configuration & Steps to reproduce

Umbrella app:

```
|-- apps
|    |-- admin              // Kaffy Admin
|    |    |-- lib/admin/kaffy/extension.ex. // Extension module
|    |    |-- mix.exs      // here Kaffy was added to the deps
|    |
|    |-- (...)          // other umbrella apps
|
|-- config
|    |-- config.exs      // Kaffy config here
|    |-- (...)
|
(...)
```

```elixir
# apps/admin/lib/admin/kaffy/extension.ex
defmodule Admin.Kaffy.Extension do
  @moduledoc """
  Kaffy extensions

  Imports custom css and js files.
  """

  def stylesheets(_conn) do
    [
      {:safe, ~s(<link rel="stylesheet" href="/admin/assets/app.css" />)}
    ]
  end

  def javascripts(_conn) do
    [
      {:safe, ~s(<script src="/admin/assets/app.js"></script>)}
    ]
  end
end
```

```elixir
# apps/admin/mix.exs
defmodule Admin.MixProject do
  use Mix.Project
  
  (...)

  defp deps do
    [
      (...)
      {:kaffy, "~> 0.9.2"},
      (...)
    ]
  end
end
```

```elixir
# config/config.exs
(...)
config :kaffy,
  otp_app: :admin,
  ecto_repo: Core.Repo,
  router: Admin.Router,
  admin_title: "My Admin Panel",
  admin_logo: "/admin/images/logo.png",
  admin_logo_mini: "/admin/images/logo-min.png",
  extensions: [
    Admin.Kaffy.Extension
  ],
  resources: &Admin.Kaffy.Resources.build_resources/1
  
(...)
```

**Steps to reproduce**

In the umbrella app:

1. start the server

```
$ mix phx.server
```

2. Open admin panel in web browser. See that custom styles are not applied, and `<link rel="stylesheet" href="/admin/assets/app.css" />` is not present in the DOM.

3. Make any change in `apps/admin/lib/admin/kaffy/extension.ex`

4. Go back to the web browser and refresh the page. Now, the custom styles are applied and `/admin/assets/app.css` can be found in DOM.


