### PR TITLE
Support hiding menu entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ defmodule MyApp.Kaffy.Config do
         resources: [ # this line used to be "schemas" in pre v0.9
           post: [schema: MyApp.Blog.Post, admin: MyApp.SomeModule.Anywhere.PostAdmin],
           comment: [schema: MyApp.Blog.Comment],
-          tag: [schema: MyApp.Blog.Tag]
+          tag: [schema: MyApp.Blog.Tag, in_menu: false]
         ]
       ],
       inventory: [

--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -428,4 +428,8 @@ defmodule Kaffy.Utils do
   def get_task_modules() do
     env(:scheduled_tasks, [])
   end
+
+  def visible?(options) do
+    Keyword.get(options, :in_menu, true)
+  end
 end

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -100,7 +100,7 @@
                     <div class="collapse<%= if @conn.assigns[:context] == to_string(context) do %> show<% end %>" id="<%= context %>-context">
                       <ul class="nav flex-column sub-menu">
                         <%= for {resource, options} <- Kaffy.Utils.schemas_for_context(@conn, context) do %>
-                            <%= if Kaffy.ResourceAdmin.authorized?(options, @conn) do %>
+                            <%= if Kaffy.ResourceAdmin.authorized?(options, @conn) && Kaffy.Utils.visible?(options) do %>
                                 <li class="nav-item"><%= link Kaffy.ResourceAdmin.plural_name(options), to: Kaffy.Utils.router().kaffy_resource_path(@conn, :index, context, resource), class: "nav-link" %></li>
                                 <%= for custom_link <- Kaffy.ResourceAdmin.custom_links(options, :sub) do %>
                                     <li class="nav-item"><%= link custom_link.name, to: custom_link.url, class: "nav-link", target: custom_link.target %></li>


### PR DESCRIPTION
**Problem**
I have a schema that is replicated across 2 submodules, one for writing, one for reading.
I want to show it only once in the menu, and use the changeset of the submodule that writes that schema.
I need to specify it in the Kaffy Config resources for the module that only reads it, otherwise schemas that depend on it from that sumodule cannot be edited (raise error when accessing the edit view because it cannot find a schema for the specified relation).

