### PR TITLE
Fix changeset errors

### DIFF
--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -62,6 +62,9 @@ defmodule Kaffy.ResourceCallbacks do
       {:error, :not_found} ->
         Kaffy.Utils.repo().update(changeset)
 
+      {:error, error} ->
+        {:error, error}
+
       unexpected_error ->
         {:error, unexpected_error}
     end

--- a/lib/kaffy/resource_callbacks.ex
+++ b/lib/kaffy/resource_callbacks.ex
@@ -30,6 +30,9 @@ defmodule Kaffy.ResourceCallbacks do
       {:error, :not_found} ->
         Kaffy.Utils.repo().insert(changeset)
 
+      {:error, error} ->
+        {:error, error}
+
       unexpected_error ->
         {:error, unexpected_error}
     end
@@ -167,6 +170,9 @@ defmodule Kaffy.ResourceCallbacks do
     else
       {:error, :not_found} ->
         Kaffy.Utils.repo().delete(changeset)
+
+      {:error, error} ->
+        {:error, error}
 
       unexpected_error ->
         {:error, unexpected_error}

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -130,7 +130,7 @@ defmodule Kaffy.ResourceForm do
         text_input(form, field, opts)
 
       :richtext ->
-        opts = Keyword.put(opts, :class, "kaffy-editor")
+        opts = add_class(opts, "kaffy-editor")
         textarea(form, field, opts)
 
       :textarea ->
@@ -146,8 +146,8 @@ defmodule Kaffy.ResourceForm do
         text_input(form, field, opts)
 
       t when t in [:boolean, :boolean_checkbox] ->
-        checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
-        label_opts = Keyword.put(opts, :class, "custom-control-label")
+        checkbox_opts = add_class(opts, "custom-control-input")
+        label_opts = add_class(opts, "custom-control-label")
 
         [
           {:safe, ~s(<div class="custom-control custom-checkbox">)},
@@ -157,8 +157,8 @@ defmodule Kaffy.ResourceForm do
         ]
 
       :boolean_switch ->
-        checkbox_opts = Keyword.put(opts, :class, "custom-control-input")
-        label_opts = Keyword.put(opts, :class, "custom-control-label")
+        checkbox_opts = add_class(opts, "custom-control-input")
+        label_opts = add_class(opts, "custom-control-label")
 
         [
           {:safe, ~s(<div class="custom-control custom-switch">)},
@@ -294,8 +294,8 @@ defmodule Kaffy.ResourceForm do
   end
 
   defp flatpickr_generic(form, field, opts, placeholder, fp_class, icon \\ "📅") do
-    opts = Keyword.put(opts, :class, "flatpickr-input")
-    opts = Keyword.put(opts, :class, "form-control")
+    opts = add_class(opts, "flatpickr-input")
+    opts = add_class(opts, "form-control")
     opts = Keyword.put(opts, :id, "inlineFormInputGroup")
     opts = Keyword.put(opts, :placeholder, placeholder)
     opts = Keyword.put(opts, :"data-input", "")
@@ -470,5 +470,9 @@ defmodule Kaffy.ResourceForm do
           [label_tag, field_tag, field_feeback]
         end
     end
+  end
+
+  defp add_class(opts, class) do
+    Keyword.update(opts, :class, class, &"#{&1} #{class}")
   end
 end

--- a/priv/static/assets/scss/style.css
+++ b/priv/static/assets/scss/style.css
@@ -4758,7 +4758,6 @@ textarea.form-control {
 }
 
 .invalid-feedback {
-  display: none;
   width: 100%;
   margin-top: 0.25rem;
   font-size: 80%;


### PR DESCRIPTION
This fixes error handing, example:

<img width="813" alt="image" src="https://user-images.githubusercontent.com/6031161/224654110-120b0111-f455-4131-bd5d-8089d2b658e7.png">

There are two changes. First of all we had an issue that this was not working at all and throwing like this: 
```
(CaseClauseError no case clause matching: {:error, {:error, #Ecto.Changeset<action: :update, changes: %{is_admin: "**redacted**"}, errors: [is_admin: {"cannot set is_admin for non official emails", []}], data: #Api.Accounts.User<>, valid?: false>}})
```

This happens because the error handling in `lib/kaffy/resource_callbacks.ex` wraps the "unexpected" errors in the error tuple, which is pointless when the error is already an error tuple. For example this results in `{:error, {:error, Ecto.Changeset.t()}}` tuple which can't be then handled correctly.

Second after I fixed this I noticed the errors are not displayed in details so this was the second part of the fix. You can notice I added a simple helper function - `add_class/2` which basically appends the class in the opts instead of overwriting it every time. We have even places where we put the new class one after another which makes the old value redundant. 