### PR TITLE
Dynamic Primary Keys

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -2,6 +2,8 @@ defmodule Kaffy.ResourceAdmin do
   alias Kaffy.ResourceSchema
   alias Kaffy.Utils
 
+  @default_id_separator "."
+
   @moduledoc """
   ResourceAdmin modules should be created for every schema you want to customize/configure in Kaffy.
 
@@ -119,7 +121,7 @@ defmodule Kaffy.ResourceAdmin do
   @doc """
   `ordering/1` takes a schema and returns how the entries should be ordered.
 
-  If `ordering/1` is not defined, Kaffy will return `[desc: :id]`.
+  If `ordering/1` is not defined, Kaffy will return `[desc: primary_key]`, or the first field of the primary key, if it's a composite.
 
   ## Examples
 
@@ -130,7 +132,10 @@ defmodule Kaffy.ResourceAdmin do
   ```
   """
   def ordering(resource) do
-    Utils.get_assigned_value_or_default(resource, :ordering, desc: :id)
+    schema = resource[:schema]
+    [order_key | _] = ResourceSchema.primary_keys(schema)
+
+    Utils.get_assigned_value_or_default(resource, :ordering, desc: order_key)
   end
 
   @doc """
@@ -300,6 +305,52 @@ defmodule Kaffy.ResourceAdmin do
   def plural_name(resource) do
     default = singular_name(resource) |> Kaffy.Inflector.pluralize()
     Utils.get_assigned_value_or_default(resource, :plural_name, default)
+  end
+
+  @doc """
+  `serialize_id/2` takes a schema and record and must return a string to be used in the URL and form values.
+
+  If `serialize_id/2` is not defined, Kaffy will concatenate multiple primary keys with `"."` as a separator.
+
+  Example:
+
+  ```elixir
+  def serialize_id(_schema, record) do
+    Enum.join([record.post_id, record.tag_id], ".")
+  end
+  ```
+  """
+  def serialize_id(resource, entry) do
+    schema = resource[:schema]
+    default = schema
+      |> ResourceSchema.primary_keys()
+      |> Enum.map_join(@default_id_separator, &Map.get(entry, &1))
+
+    Utils.get_assigned_value_or_default(resource, :serialize_id, default, [entry])
+  end
+
+  @doc """
+  `deserialize_id/2` takes a schema and serialized id and must return a complete
+  keyword list in the form of [{:primary_key, value}, ...].
+
+  If `deserialize_id/2` is not defined, Kaffy will split multiple primary keys with `"."` as a separator.
+
+  Example:
+
+  ```elixir
+  def serialize_id(_schema, serialized_id) do
+    Enum.zip([:post_id, :tag_id], String.split(serialized_id, "."))
+  end
+  ```
+  """
+  def deserialize_id(resource, id) do
+    schema = resource[:schema]
+    id_list = String.split(id, @default_id_separator)
+    default = schema
+      |> ResourceSchema.primary_keys()
+      |> Enum.zip(id_list)
+
+    Utils.get_assigned_value_or_default(resource, :deserialize_id, default, [id])
   end
 
   def resource_actions(resource, conn) do

--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -2,7 +2,7 @@ defmodule Kaffy.ResourceAdmin do
   alias Kaffy.ResourceSchema
   alias Kaffy.Utils
 
-  @default_id_separator "."
+  @default_id_separator ":"
 
   @moduledoc """
   ResourceAdmin modules should be created for every schema you want to customize/configure in Kaffy.
@@ -310,13 +310,13 @@ defmodule Kaffy.ResourceAdmin do
   @doc """
   `serialize_id/2` takes a schema and record and must return a string to be used in the URL and form values.
 
-  If `serialize_id/2` is not defined, Kaffy will concatenate multiple primary keys with `"."` as a separator.
+  If `serialize_id/2` is not defined, Kaffy will concatenate multiple primary keys with `":"` as a separator.
 
   Example:
 
   ```elixir
   def serialize_id(_schema, record) do
-    Enum.join([record.post_id, record.tag_id], ".")
+    Enum.join([record.post_id, record.tag_id], ":")
   end
   ```
   """
@@ -333,13 +333,13 @@ defmodule Kaffy.ResourceAdmin do
   `deserialize_id/2` takes a schema and serialized id and must return a complete
   keyword list in the form of [{:primary_key, value}, ...].
 
-  If `deserialize_id/2` is not defined, Kaffy will split multiple primary keys with `"."` as a separator.
+  If `deserialize_id/2` is not defined, Kaffy will split multiple primary keys with `":"` as a separator.
 
   Example:
 
   ```elixir
   def serialize_id(_schema, serialized_id) do
-    Enum.zip([:post_id, :tag_id], String.split(serialized_id, "."))
+    Enum.zip([:post_id, :tag_id], String.split(serialized_id, ":"))
   end
   ```
   """

--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -312,11 +312,19 @@ defmodule Kaffy.ResourceAdmin do
 
   If `serialize_id/2` is not defined, Kaffy will concatenate multiple primary keys with `":"` as a separator.
 
-  Example:
+  Examples:
 
   ```elixir
+  # Default method with fixed keys
   def serialize_id(_schema, record) do
     Enum.join([record.post_id, record.tag_id], ":")
+  end
+
+  # ETF
+  def serialize_id(_schema, record) do
+    {record.post_id, record.tag_id}
+    |> :erlang.term_to_binary()
+    |> Base.url_encode64()
   end
   ```
   """
@@ -335,11 +343,21 @@ defmodule Kaffy.ResourceAdmin do
 
   If `deserialize_id/2` is not defined, Kaffy will split multiple primary keys with `":"` as a separator.
 
-  Example:
+  Examples:
 
   ```elixir
-  def serialize_id(_schema, serialized_id) do
+  # Default method with fixed keys
+  def deserialize_id(_schema, serialized_id) do
     Enum.zip([:post_id, :tag_id], String.split(serialized_id, ":"))
+  end
+
+  # Deserialize from ETF
+  def deserialize_id(_schema, serialized_id) do
+    {product_id, tag_id} = serialized_id
+    |> Base.url_decode64!()
+    |> :erlang.binary_to_term()
+
+    [product_id: product_id, tag_id: tag_id]
   end
   ```
   """

--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -47,8 +47,14 @@ defmodule Kaffy.ResourceForm do
         opts
       end
 
+    # Check if any primary key fields are nil
+    is_create_event = changeset.data.__struct__
+      |> Kaffy.ResourceSchema.primary_keys()
+      |> Enum.map(&Map.get(changeset.data, &1))
+      |> Enum.any?(&is_nil/1)
+
     permission =
-      case is_nil(changeset.data.id) do
+      case is_create_event do
         true -> Map.get(options, :create, :editable)
         false -> Map.get(options, :update, :editable)
       end
@@ -115,13 +121,13 @@ defmodule Kaffy.ResourceForm do
         textarea(form, field, [value: value, rows: 4, placeholder: "JSON Content"] ++ opts)
 
       :id ->
-        case Kaffy.ResourceSchema.primary_key(schema) == [field] do
+        case field in Kaffy.ResourceSchema.primary_keys(schema) do
           true -> text_input(form, field, opts)
           false -> text_or_assoc(conn, schema, form, field, opts)
         end
 
       :binary_id ->
-        case Kaffy.ResourceSchema.primary_key(schema) == [field] do
+        case field in Kaffy.ResourceSchema.primary_keys(schema) do
           true -> text_input(form, field, opts)
           false -> text_or_assoc(conn, schema, form, field, opts)
         end

--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -52,7 +52,9 @@ defmodule Kaffy.ResourceQuery do
 
   def fetch_resource(conn, resource, id) do
     schema = resource[:schema]
-    query = from(s in schema, where: s.id == ^id)
+
+    id_filter = Kaffy.ResourceAdmin.deserialize_id(resource, id)
+    query = from(s in schema, where: ^id_filter)
 
     case Kaffy.ResourceAdmin.custom_show_query(conn, resource, query) do
       {custom_query, opts} -> Kaffy.Utils.repo().one(custom_query, opts)

--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -67,8 +67,13 @@ defmodule Kaffy.ResourceQuery do
   def fetch_list(resource, ids) do
     schema = resource[:schema]
 
-    from(s in schema, where: s.id in ^ids)
-    |> Kaffy.Utils.repo().all()
+    primary_keys = Kaffy.ResourceSchema.primary_keys(schema)
+    ids = Enum.map(ids, &Kaffy.ResourceAdmin.deserialize_id(resource, &1))
+
+    case build_list_query(schema, primary_keys, ids) do
+      {:error, error_msg} -> {:error, error_msg}
+      query -> Kaffy.Utils.repo().all(query)
+    end
   end
 
   def total_count(schema, do_cache, query, opts \\ [])
@@ -149,6 +154,22 @@ defmodule Kaffy.ResourceQuery do
       from(s in query, limit: ^per_page, offset: ^current_offset, order_by: ^ordering)
 
     {query, limited_query}
+  end
+
+
+  defp build_list_query(_schema, [], _key_pairs) do
+    {:error, "No private keys. List action not supported."}
+  end
+
+  defp build_list_query(schema, [primary_key], ids) do
+    ids = Enum.map(ids, fn [{_key, id}] -> id end)
+    from(s in schema, where: field(s, ^primary_key) in ^ids)
+  end
+
+  defp build_list_query(schema, _composite_key, key_pairs) do
+    Enum.reduce(key_pairs, schema, fn pair, query_acc ->
+      from query_acc, or_where: ^pair
+    end)
   end
 
   defp build_filtered_fields_query(query, []), do: query

--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -156,7 +156,6 @@ defmodule Kaffy.ResourceQuery do
     {query, limited_query}
   end
 
-
   defp build_list_query(_schema, [], _key_pairs) do
     {:error, "No private keys. List action not supported."}
   end

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -1,7 +1,7 @@
 defmodule Kaffy.ResourceSchema do
   @moduledoc false
 
-  def primary_key(schema) do
+  def primary_keys(schema) do
     schema.__schema__(:primary_key)
   end
 
@@ -24,7 +24,10 @@ defmodule Kaffy.ResourceSchema do
   end
 
   def form_fields(schema) do
-    to_be_removed = fields_to_be_removed(schema) ++ [:id, :inserted_at, :updated_at]
+    to_be_removed =
+      fields_to_be_removed(schema) ++
+        primary_keys(schema) ++
+        [:inserted_at, :updated_at]
     Keyword.drop(fields(schema), to_be_removed)
   end
 
@@ -33,7 +36,9 @@ defmodule Kaffy.ResourceSchema do
       fields_to_be_removed(schema) ++
         get_has_many_associations(schema) ++
         get_has_one_assocations(schema) ++
-        get_many_to_many_associations(schema) ++ [:id, :inserted_at, :updated_at]
+        get_many_to_many_associations(schema) ++
+        primary_keys(schema) ++
+        [:inserted_at, :updated_at]
 
     Keyword.drop(fields(schema), to_be_removed)
   end

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -391,6 +391,8 @@ defmodule KaffyWeb.ResourceController do
   end
 
   defp redirect_to_resource(conn, context, resource, entry) do
+    id = Kaffy.ResourceAdmin.serialize_id(resource, entry)
+
     redirect(conn,
       to:
         Kaffy.Utils.router().kaffy_resource_path(
@@ -398,7 +400,7 @@ defmodule KaffyWeb.ResourceController do
           :show,
           context,
           resource,
-          entry.id
+          id
         )
     )
   end

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -349,11 +349,14 @@ defmodule KaffyWeb.ResourceController do
     action_record = get_action_record(actions, action_key)
     kaffy_inputs = Map.get(params, "kaffy-input", %{})
 
-    result =
-      case Map.get(action_record, :inputs, []) do
-        [] -> action_record.action.(conn, entries)
-        _ -> action_record.action.(conn, entries, kaffy_inputs)
-      end
+    result = case entries do
+      {:error, error_msg} -> {:error, error_msg}
+      entries ->
+        case Map.get(action_record, :inputs, []) do
+          [] -> action_record.action.(conn, entries)
+          _ -> action_record.action.(conn, entries, kaffy_inputs)
+        end
+    end
 
     case result do
       :ok ->

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -394,7 +394,8 @@ defmodule KaffyWeb.ResourceController do
   end
 
   defp redirect_to_resource(conn, context, resource, entry) do
-    id = Kaffy.ResourceAdmin.serialize_id(resource, entry)
+    my_resource = Kaffy.Utils.get_resource(conn, context, resource)
+    id = Kaffy.ResourceAdmin.serialize_id(my_resource, entry)
 
     redirect(conn,
       to:

--- a/lib/kaffy_web/templates/resource/_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_table.html.eex
@@ -4,17 +4,17 @@
     </thead>
 
     <tbody>
-        <%= for entry <- @entries do %>
+        <%= for {entry, index} <- Enum.with_index(@entries) do %>
             <tr>
                 <td>
                     <div class="custom-control custom-checkbox">
-                        <input type="checkbox" class="custom-control-input select-item kaffy-resource-checkbox" id="kaffy-select-<%= entry.id %>" name="resource" value="<%= entry.id %>"/>
-                        <label class="custom-control-label" for="kaffy-select-<%= entry.id %>"></label>
+                        <input type="checkbox" class="custom-control-input select-item kaffy-resource-checkbox" id="kaffy-select-<%= index %>" name="resource" value="<%= Kaffy.ResourceAdmin.serialize_id(@my_resource, entry) %>"/>
+                        <label class="custom-control-label" for="kaffy-select-<%= index %>"></label>
                     </div>
                 </td>
                 <%= for {field, index} <- Enum.with_index(@fields) do %>
                     <%= if index == 0 do %>
-                        <td><%= link Kaffy.ResourceSchema.kaffy_field_value(@conn, entry, field), to: Kaffy.Utils.router().kaffy_resource_path(@conn, :show, @context, @resource, entry.id) %></td>
+                        <td><%= link Kaffy.ResourceSchema.kaffy_field_value(@conn, entry, field), to: Kaffy.Utils.router().kaffy_resource_path(@conn, :show, @context, @resource, Kaffy.ResourceAdmin.serialize_id(@my_resource, entry)) %></td>
                     <% else %>
                         <td><%= Kaffy.ResourceSchema.kaffy_field_value(@conn, entry, field) %></td>
                     <% end %>

--- a/lib/kaffy_web/templates/resource/show.html.eex
+++ b/lib/kaffy_web/templates/resource/show.html.eex
@@ -9,7 +9,7 @@
         <div class="card-header">
             <div class="row justify-content-between">
                 <div class="col-auto mr-auto">
-                    <h1><%= @resource_name %> #<%= @changeset.data.id %></h1>
+                    <h1><%= @resource_name %> #<%= Kaffy.ResourceAdmin.serialize_id(@my_resource, @changeset.data) %></h1>
                 </div>
                 <div class="col-auto">
                     <%= if Kaffy.ResourceAdmin.resource_actions(@my_resource, @conn) do %>
@@ -20,7 +20,7 @@
                                 </button>
                                 <div class="dropdown-menu">
                                     <%= for {action_key, options} <- Kaffy.ResourceAdmin.resource_actions(@my_resource, @conn) do %>
-                                        <%= form_tag(Kaffy.Utils.router().kaffy_resource_path(@conn, :single_action, @context, @resource, @changeset.data.id, to_string(action_key)), method: :post) %>
+                                        <%= form_tag(Kaffy.Utils.router().kaffy_resource_path(@conn, :single_action, @context, @resource, Kaffy.ResourceAdmin.serialize_id(@my_resource, @changeset.data), to_string(action_key)), method: :post) %>
                                             <input type="submit" name="submit" value="<%= options.name %>" class="dropdown-item" />
                                         </form>
                                     <% end %>
@@ -32,7 +32,7 @@
             </div>
         </div>
         <div class="card-body">
-            <%= form_for @changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :update, @context, @resource, @changeset.data.id), [method: :put, multipart: true], fn f -> %>
+            <%= form_for @changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :update, @context, @resource, Kaffy.ResourceAdmin.serialize_id(@my_resource, @changeset.data)), [method: :put, multipart: true], fn f -> %>
                 <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
                     <%= if options.update != :hidden do %>
                         <%= Kaffy.ResourceForm.kaffy_input @conn, @changeset, f, field, options %>
@@ -53,7 +53,7 @@
     </div>
 
     <!-- Modal -->
-    <%= form_for @changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :delete, @context, @resource, @changeset.data.id), [method: :delete], fn _f -> %>
+    <%= form_for @changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :delete, @context, @resource, Kaffy.ResourceAdmin.serialize_id(@my_resource, @changeset.data)), [method: :delete], fn _f -> %>
         <div class="modal fade" id="delete-modal" tabindex="-1" role="dialog" aria-labelledby="delete-modal-label" aria-hidden="true">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">

--- a/test/actions_test.exs
+++ b/test/actions_test.exs
@@ -67,6 +67,35 @@ defmodule ActionsTest do
     end
   end
 
+  defmodule ActionsCompositeKeyAdmin do
+    @string_action "test_action"
+    @response %{product_id: 1, tag_id: 1}
+
+    def index(_), do: []
+
+    def resource_actions(_conn) do
+      %{
+        @string_action => %{
+          name: "Test Action",
+          action: fn _, _ ->
+            {:ok, @response}
+          end
+        }
+      }
+    end
+
+    def list_actions(_conn) do
+      %{
+        @string_action => %{
+          name: "Test Action",
+          action: fn _, _ ->
+            :ok
+          end
+        }
+      }
+    end
+  end
+
   defmodule FakeSchema do
     use Ecto.Schema
 
@@ -98,6 +127,12 @@ defmodule ActionsTest do
           name: "map",
           resources: [
             test: [schema: FakeSchema, admin: ActionsMapAdmin]
+          ]
+        ],
+        composite: [
+          name: "composite",
+          resources: [
+            test: [schema: KaffyTest.Schemas.Owner, admin: ActionsCompositeKeyAdmin]
           ]
         ]
       ]
@@ -135,6 +170,34 @@ defmodule ActionsTest do
           "resource" => "test",
           "action_key" => "test_action",
           "id" => "id"
+        })
+
+      assert %{"success" => _} = get_flash(result_conn)
+    end
+  end
+
+  test "single action handles composite primary keys", %{conn: conn} do
+    with_mock Kaffy.ResourceQuery, fetch_resource: fn _, _, _ -> %{product_id: 1, tag_id: 1} end do
+      result_conn =
+        ResourceController.single_action(conn, %{
+          "context" => "composite",
+          "resource" => "test",
+          "action_key" => "test_action",
+          "id" => "1:1"
+        })
+
+      assert %{"success" => _} = get_flash(result_conn)
+    end
+  end
+
+  test "list action handles composite primary keys", %{conn: conn} do
+    with_mock Kaffy.ResourceQuery, fetch_list: fn _, _ -> [%{product_id: 1, tag_id: 1}, %{product_id: 1, tag_id: 2}] end do
+      result_conn =
+        ResourceController.list_action(conn, %{
+          "context" => "composite",
+          "resource" => "test",
+          "action_key" => "test_action",
+          "id" => "1:1,1:2"
         })
 
       assert %{"success" => _} = get_flash(result_conn)

--- a/test/kaffy_test.exs
+++ b/test/kaffy_test.exs
@@ -1,7 +1,7 @@
 defmodule KaffyTest do
   use ExUnit.Case
   doctest Kaffy
-  alias KaffyTest.Schemas.{Company, Person, Pet}
+  alias KaffyTest.Schemas.{Company, Person, Pet, Owner}
   # alias KaffyTest.Admin.PersonAdmin
 
   test "greets the world" do
@@ -29,8 +29,12 @@ defmodule KaffyTest do
     end
 
     test "primary_key/1 should return a primary key" do
-      assert [:id] == ResourceSchema.primary_key(Person)
-      assert [:id] == ResourceSchema.primary_key(Pet)
+      assert [:id] == ResourceSchema.primary_keys(Person)
+      assert [:id] == ResourceSchema.primary_keys(Pet)
+    end
+
+    test "primary_key/1 should return a composite key" do
+      assert [:person_id, :pet_id] == ResourceSchema.primary_keys(Owner)
     end
 
     test "kaffy_field_name/2 should return the name of the field" do

--- a/test/resource_admin_test.exs
+++ b/test/resource_admin_test.exs
@@ -1,6 +1,7 @@
 defmodule Kaffy.ResourceAdminTest do
   use ExUnit.Case, async: true
   alias Kaffy.ResourceAdmin
+  alias KaffyTest.Schemas.{Owner, Pet}
 
   defmodule Cactus do
   end
@@ -13,6 +14,28 @@ defmodule Kaffy.ResourceAdminTest do
   end
 
   defmodule PersonAdmin do
+  end
+
+  defmodule PetAdmin do
+  end
+
+  defmodule OwnerAdmin do
+  end
+
+  defmodule OwnerETFAdmin do
+    def serialize_id(_schema, owner) do
+      {owner.person_id, owner.pet_id}
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64(padding: false)
+    end
+
+    def deserialize_id(_schema, serialized_id) do
+      {person_id, pet_id} = serialized_id
+      |> Base.url_decode64!(padding: false)
+      |> :erlang.binary_to_term()
+
+      [person_id: person_id, pet_id: pet_id]
+    end
   end
 
   defmodule Nested.Node do
@@ -41,6 +64,34 @@ defmodule Kaffy.ResourceAdminTest do
 
     test "use non-standard plural form" do
       assert ResourceAdmin.plural_name(schema: Person, admin: PersonAdmin) == "People"
+    end
+  end
+
+  describe "serialize_id/2" do
+    test "serialize standard id" do
+      assert ResourceAdmin.serialize_id([schema: Pet, admin: PetAdmin], %{id: 1}) == "1"
+    end
+
+    test "serialize composite id" do
+      assert ResourceAdmin.serialize_id([schema: Owner, admin: OwnerAdmin], %{person_id: 1, pet_id: 2}) == "1:2"
+    end
+
+    test "custom serialization of composite key" do
+      assert ResourceAdmin.serialize_id([schema: Owner, admin: OwnerETFAdmin], %{person_id: 1, pet_id: 2}) == "g2gCYQFhAg"
+    end
+  end
+
+  describe "deserialize_id/2" do
+    test "deserialize standard id" do
+      assert ResourceAdmin.deserialize_id([schema: Pet, admin: PetAdmin], "1") == [id: "1"]
+    end
+
+    test "deserialize composite id" do
+      assert ResourceAdmin.deserialize_id([schema: Owner, admin: OwnerAdmin], "1:2") == [person_id: "1", pet_id: "2"]
+    end
+
+    test "custom deserialization of composite key" do
+      assert ResourceAdmin.deserialize_id([schema: Owner, admin: OwnerETFAdmin], "g2gCYQFhAg") == [person_id: "1", pet_id: "2"]
     end
   end
 end

--- a/test/resource_admin_test.exs
+++ b/test/resource_admin_test.exs
@@ -91,7 +91,7 @@ defmodule Kaffy.ResourceAdminTest do
     end
 
     test "custom deserialization of composite key" do
-      assert ResourceAdmin.deserialize_id([schema: Owner, admin: OwnerETFAdmin], "g2gCYQFhAg") == [person_id: "1", pet_id: "2"]
+      assert ResourceAdmin.deserialize_id([schema: Owner, admin: OwnerETFAdmin], "g2gCYQFhAg") == [person_id: 1, pet_id: 2]
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -43,3 +43,13 @@ defmodule KaffyTest.Schemas.Company do
     has_many(:people, KaffyTest.Schemas.Person)
   end
 end
+
+defmodule KaffyTest.Schemas.Owner do
+  use Ecto.Schema
+
+  @primary_key false
+  schema "owner" do
+    field :person_id, :id, primary_key: true
+    field :pet_id, :id, primary_key: true
+  end
+end


### PR DESCRIPTION
This is the refactored version of #151, which addresses the hard-coded `id` primary key, and issues discussed in #6.

The first two commits are the same as before, with merge conflicts resolved. The rest are to implement list actions and address some of what was discussed in the linked issue, hoping to make this change a less rough around the edges. 😃

The default serialization method remains unchanged from the old PR, but the separator was changed to `":"`, and an example on how the serialization could be done with ETF instead, for cases where the former method may introduce ambiguity, was added to the docs.

For the list actions, I split the behavior as follows:

- Records with a single primary key use the same query as before and should work exactly the same, just with the key itself being pulled from the schema.

- List actions on records with a composite key use a dynamic query with an `or_where([pk1: val1, pk2: val2, ...])` clause per record. I don't love this solution, but `where: ^composite_key in ^values` type of queries are not a thing (yet?), and I found no way to get around it with `fragment`/`dynamic`/`field`/`type` trickery.

Happy to hear your thoughts!

