### PR TITLE
Add decoding for array JSON fields

### DIFF
--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -306,6 +306,9 @@ defmodule Kaffy.ResourceSchema do
       {_f, %{type: :map}} ->
         true
 
+      {_f, %{type: {:array, _}}} ->
+        true
+
       f when is_atom(f) ->
         f == :map
 


### PR DESCRIPTION
Closes #271 

As the issue describes, there seems to be missing changes from an earlier PR (#212).
This adds back JSON decoding for array fields.