### PR TITLE
Use left_join when building search query.

### DIFF
--- a/lib/kaffy/resource_query.ex
+++ b/lib/kaffy/resource_query.ex
@@ -128,7 +128,7 @@ defmodule Kaffy.ResourceQuery do
 
           Enum.reduce(search_fields, query, fn
             {association, fields}, q ->
-              query = from(s in q, join: a in assoc(s, ^association))
+              query = from(s in q, left_join: a in assoc(s, ^association))
 
               Enum.reduce(fields, query, fn f, current_query ->
                 from([..., r] in current_query,


### PR DESCRIPTION
This allows consistent search results when using preloads in a `custom_index_query`, and `search_fields`.

I ran into issues when trying to search my `Profile` schema by `User.email`.  Changing to a left join allowed the search filter to work, and provided consistent results.

Schema Modules
```elixir
defmodule MyApp.Profile do

  schema "profiles" do
    belongs_to :user, User
    field :display_name, :string
    ...
  end

end

defmodule MyApp.User do
  
  schema "users" do
    has_one :profile, Profile
    field :email, :string
    ...
  end

end


```

Admin Module
```elixir
defmodule MyApp.ProfileAdmin

  def custom_index_query(_conn, _schema, query) do
    from(r in query, preload: [:user])
  end

  def search_fields(_schema) do
    [
      :display_name,
      user: [:email]
    ]
  end
```


