### PR TITLE
#252 The :admin_footer can be specified in app config as nil, or String.t(…

### DIFF
--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -10,6 +10,14 @@ defmodule Kaffy.Utils do
   end
 
   @doc """
+  Returns the :admin_footer config if present, otherwise returns default copyright.
+  """
+  @spec footer() :: String.t() | {:safe, String.t()}
+  def footer() do
+    env(:admin_footer, "Copyright © 2022 Kaffy. All rights reserved.")
+  end
+
+  @doc """
   Returns the static path to the asset.
   """
   @spec static_asset_path(Plug.Conn.t(), String.t()) :: String.t()

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -155,7 +155,9 @@
 
           <footer class="footer">
             <div class="d-sm-flex justify-content-center justify-content-sm-between">
-              <span class="text-muted text-center text-sm-left d-block d-sm-inline-block">Copyright © 2022 Kaffy. All rights reserved.</span>
+              <%= if copyright = Kaffy.Utils.footer() do %>
+                <span class="text-muted text-center text-sm-left d-block d-sm-inline-block"><%= copyright %></span>
+              <% end %>
             </div>
           </footer>
 


### PR DESCRIPTION
The `:admin_footer` can optionally be specified in app config as `nil`, or `String.t()`, or `{:safe, String.t()}`.

`:admin_footer` Not specified
![Screenshot 2023-06-12 at 4 04 05 PM](https://github.com/aesmail/kaffy/assets/1435196/032a173c-9438-41e8-909f-03e611ba6ad1)

`:admin_footer` specified as`nil`
![Screenshot 2023-06-12 at 4 04 05 PM](https://github.com/aesmail/kaffy/assets/1435196/0c9aae00-ce43-47e3-9790-3f81bfef3fce)

`:admin_footer` specified as `String.t()`
![Screenshot 2023-06-12 at 3 57 13 PM](https://github.com/aesmail/kaffy/assets/1435196/d23f6a82-72f8-4f31-a8c1-39236396245c)

`:admin_footer` specified as `{:safe, String.t()}`
![Screenshot 2023-06-12 at 3 57 13 PM](https://github.com/aesmail/kaffy/assets/1435196/b4fac9d3-9b7b-4300-8576-4526d2cbeafd)




