### PR TITLE
add path to `endpoint.ex` in installation guide for Phoenix 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Follow the instructions at https://hexdocs.pm/phoenix_view/Phoenix.View.html
 
 You will also need to change `helpers: false` to `true` as shown in example below.
 ```elixir
+# in your lib/you_app_web/endpoint.ex
   def router do
     quote do
       use Phoenix.Router, helpers: true


### PR DESCRIPTION
Added clarification for newbies (like me) on where (endpoint) to enable Router Helpers so that kaffy works in Phoenix 1.7