### PR TITLE
filter erlang modules out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.1 (2023-10-09)
+
+### Fixes
+- Fix a crash when Kaffy mistakenly treats erlang modules as Elixir modules (PR #300)
+
 ## v0.10.0 (2023-10-06)
 
 ### Fixes

--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -332,7 +332,7 @@ defmodule Kaffy.Utils do
   end
 
   @doc """
-  Returns true if `thing` is a module, false otherwise.
+  Returns true if `thing` is an elixir module, false otherwise.
   """
   @spec is_module(module()) :: boolean()
   def is_module(thing), do: is_atom(thing) && function_exported?(thing, :__info__, 1)
@@ -432,8 +432,12 @@ defmodule Kaffy.Utils do
 
   defp get_schemas(mods) do
     Enum.filter(mods, fn m ->
-      functions = m.__info__(:functions)
-      Keyword.has_key?(functions, :__schema__) && Map.has_key?(m.__struct__, :__meta__)
+      if is_module(m) do
+        functions = m.__info__(:functions)
+        Keyword.has_key?(functions, :__schema__) && Map.has_key?(m.__struct__, :__meta__)
+      else
+        false
+      end
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Kaffy.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/aesmail/kaffy"
-  @version "0.10.0"
+  @version "0.10.1"
 
   def project do
     [


### PR DESCRIPTION
erlang modules should not be treated as elixir modules and they should be filtered out when scanning the code for schema modules.