### PR TITLE
Bug fix pagination

### DIFF
--- a/lib/kaffy/pagination.ex
+++ b/lib/kaffy/pagination.ex
@@ -4,7 +4,7 @@ defmodule Kaffy.Pagination do
   # number of pages to show on the showleft/right of the current page
   @pagination_delta 2
 
-  def get_pages(0, 0), do: []
+  def get_pages(1, 0), do: []
 
   def get_pages(current_page, total_page) do
     showleft = current_page - @pagination_delta

--- a/test/pagination_test.exs
+++ b/test/pagination_test.exs
@@ -5,7 +5,7 @@ defmodule Kaffy.PaginationTest do
   # testing for get_pages(current_page, total_page)
 
   test "test on empty pages" do
-    pages = Pagination.get_pages(0, 0)
+    pages = Pagination.get_pages(1, 0)
     assert pages == []
   end
 


### PR DESCRIPTION
The following error occurs because the startup page is 1 when the number of resources is 0.
(https://github.com/aesmail/kaffy/blob/master/lib/kaffy_web/controllers/resource_controller.ex#L35)

<img width="311" alt="image" src="https://github.com/aesmail/kaffy/assets/43606066/35286da0-8327-4877-aab9-f7970007f60d">

So have to change the `Kaffy.Pagination.get_pages/2`