### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Starting with v0.10.0, Kaffy will officially support the latest two phoenix vers
 
 | Kaffy   | Supported phoenix versions |
 |---------|----------------------------|
-| v0.10.0 | 1.6, 1.7                   |
-| v0.9.X  | 1.5, 1.6, 1.7              |
+| v0.10.0 | 1.6, 1.7.0                 |
+| v0.9.X  | 1.5, 1.6, 1.7.0            |
 |         |                            |
 
 


### PR DESCRIPTION
As Phoenix 1.7.10 doesn't work just as is with Kaffy.

More info found in issue #305 
There is also a PR #306 that might fix 1.7.10 versions according to changelog stated https://hexdocs.pm/phoenix_html/changelog.html