### PR TITLE
Geo Point support

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -282,6 +282,14 @@ defmodule Kaffy.ResourceForm do
       :utc_datetime_usec ->
         flatpickr_datetime_usec(form, field, opts)
 
+      Geo.PostGIS.Geometry ->
+        value =
+          data
+          |> Map.get(field, "")
+          |> Kaffy.Utils.json().encode!(escape: :html_safe, pretty: true)
+
+        textarea(form, field, [value: value, rows: 4, placeholder: "JSON Content"] ++ opts)
+
       _ ->
         text_input(form, field, opts)
     end

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -176,12 +176,15 @@ defmodule Kaffy.ResourceSchema do
         value.(schema)
 
       is_map(value) && Map.has_key?(value, :__struct__) ->
-        if value.__struct__ in [NaiveDateTime, DateTime, Date, Time] do
-          value
-        else
-          Map.from_struct(value)
-          |> Map.drop([:__meta__])
-          |> Kaffy.Utils.json().encode!(escape: :html_safe, pretty: true)
+        cond do
+          value.__struct__ in [NaiveDateTime, DateTime, Date, Time] ->
+            value
+          value.__struct__ in [Geo.Point] ->
+            Kaffy.Utils.json().encode!(value, escape: :html_safe, pretty: true)
+          true ->
+            Map.from_struct(value)
+            |> Map.drop([:__meta__])
+            |> Kaffy.Utils.json().encode!(escape: :html_safe, pretty: true)
         end
 
       Kaffy.Utils.is_module(ft) && Keyword.has_key?(ft.__info__(:functions), :render_index) ->
@@ -206,12 +209,15 @@ defmodule Kaffy.ResourceSchema do
         value
 
       is_map(value) && Map.has_key?(value, :__struct__) ->
-        if value.__struct__ in [NaiveDateTime, DateTime, Date, Time] do
-          value
-        else
-          Map.from_struct(value)
-          |> Map.drop([:__meta__])
-          |> Kaffy.Utils.json().encode!(escape: :html_safe, pretty: true)
+        cond do
+          value.__struct__ in [NaiveDateTime, DateTime, Date, Time] ->
+            value
+          value.__struct__ in [Geo.Point] ->
+            Kaffy.Utils.json().encode!(value, escape: :html_safe, pretty: true)
+          true ->
+            Map.from_struct(value)
+            |> Map.drop([:__meta__])
+            |> Kaffy.Utils.json().encode!(escape: :html_safe, pretty: true)
         end
 
       is_map(value) ->
@@ -318,6 +324,9 @@ defmodule Kaffy.ResourceSchema do
         true
 
       {_f, %{type: {:array, _}}} ->
+        true
+
+      {_f, %{type: Geo.PostGIS.Geometry}} ->
         true
 
       f when is_atom(f) ->


### PR DESCRIPTION
Support Geo.Point / Geo.PostGIS.Geometry fields in kaffy. As a basic first step, JSON encode / decode the geometry data for displaying and editing in the admin. Not as pretty as funky inline maps, but much more straightforward to implement, and it's better than kaffy showing big fat error messages.