### PR TITLE
Password field type

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -143,6 +143,9 @@ defmodule Kaffy.ResourceForm do
       :textarea ->
         textarea(form, field, opts)
 
+      :password ->
+        password_input(form, field, opts)
+
       :integer ->
         number_input(form, field, opts)
 


### PR DESCRIPTION
With this change, if you define:

```elixir
defmodule MyApp.UserAdmin do
  def form_fields(_) do
    [
      password: %{type: :password}
    ]
  end
end
```

Then it will display an input of type "password" in the kaffy create/edit form.

Ideally, kaffy could also infer that it should be a password input, based on the schema field having `redact: true` . But, as far as I can tell, from some quick debugging, that isn't coming through to `build_html_input/6` . Anyway, with this change, you can at least force a given field to have a password input.