### PR TITLE
Base64 for binary fields

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -152,6 +152,14 @@ defmodule Kaffy.ResourceForm do
       :decimal ->
         text_input(form, field, opts)
 
+      :binary ->
+        value =
+          data
+          |> Map.get(field, "")
+          |> Base.encode64()
+
+        text_input(form, field, [value: value] ++ opts)
+
       t when t in [:boolean, :boolean_checkbox] ->
         checkbox_opts = add_class(opts, "custom-control-input")
         label_opts = add_class(opts, "custom-control-label")

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -191,7 +191,11 @@ defmodule Kaffy.ResourceSchema do
         Kaffy.Utils.json().encode!(value, escape: :html_safe, pretty: true)
 
       is_binary(value) ->
-        value
+        if String.valid?(value) do
+          value
+        else
+          Base.encode64(value)
+        end
 
       true ->
         kaffy_field_value(schema, field)
@@ -218,7 +222,11 @@ defmodule Kaffy.ResourceSchema do
         Kaffy.Utils.json().encode!(value, escape: :html_safe, pretty: true)
 
       is_binary(value) ->
-        String.slice(value, 0, 140)
+        if String.valid?(value) do
+          String.slice(value, 0, 140)
+        else
+          Base.encode64(String.slice(value, 0, 140))
+        end
 
       is_list(value) ->
         pretty_list(value)
@@ -322,6 +330,17 @@ defmodule Kaffy.ResourceSchema do
 
       f when is_atom(f) ->
         f == :map
+
+      _ ->
+        false
+    end)
+  end
+
+  def get_binary_fields(schema) do
+    get_all_fields(schema)
+    |> Enum.filter(fn
+      {_f, %{type: :binary}} ->
+        true
 
       _ ->
         false


### PR DESCRIPTION
For fields that contain non-string binary data (e.g. random tokens), base64 encode the value for display in list views and in forms, and base64 decode the value on save.

It's unlikely that you'll want such fields to actually have their value be visible and editable in kaffy. But all fields are visible and editable by default in kaffy, and we don't want a broken out-of-the-box experience for any field types. And, in case you do want to work with such fields, they should be visible in a legible / useful format, and they should be editable without the value getting corrupted on save.