### PR TITLE
ULID form belongs_to

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -127,7 +127,7 @@ defmodule Kaffy.ResourceForm do
           false -> text_or_assoc(conn, schema, form, field, opts)
         end
 
-      :binary_id ->
+      t when t in [:binary_id, Ecto.ULID] ->
         case field in Kaffy.ResourceSchema.primary_keys(schema) do
           true -> text_input(form, field, opts)
           false -> text_or_assoc(conn, schema, form, field, opts)


### PR DESCRIPTION
Builds on #145 . Same as what that PR did for `:binary_id` , this PR makes `Ecto.ULID` work, in terms of loading `belongs_to` form select options.