### PR TITLE
accept value_fn for {:array, _} field

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -243,7 +243,14 @@ defmodule Kaffy.ResourceForm do
         case !is_nil(options[:values_fn]) && is_function(options[:values_fn], 2) do
           true ->
             values = options[:values_fn].(data, conn)
-            value = Map.get(data, field, nil)
+
+            value =
+              if is_function(options[:value_fn], 1) do
+                options[:value_fn].(data)
+              else
+                Map.get(data, field, nil)
+              end
+
             multiple_select(form, field, values, [value: value] ++ opts)
 
           false ->


### PR DESCRIPTION
This change will allow to define a :value_fn for any {:array, _} field. I use it as work-around for many_to_many associations. What I do is adding the field in the Kaffy.MyModelAdmin.form_fields/1

```
def form_fields(schema) do 
    Kaffy.ResourceSchema.form_fields(schema)
    |> Keyword.put(:associated_entities, %{
      type: {:array, :integer},
      value_fn: fn model ->
        Repo.preload(model, [:other_entities])
        |> Map.get(:other_entities)
        |> Enum.map(& &1.id)
      end,
      values_fn: fn _, _ ->
        Repo.all(Models.Entity)
        |> Enum.map(&{&1.name, &1.id})
      end
    })
end
```  