### PR TITLE
Assoc number or text input

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -124,13 +124,13 @@ defmodule Kaffy.ResourceForm do
       :id ->
         case field in Kaffy.ResourceSchema.primary_keys(schema) do
           true -> text_input(form, field, opts)
-          false -> text_or_assoc(conn, schema, form, field, opts)
+          false -> text_or_assoc(conn, schema, form, field, type, opts)
         end
 
       t when t in [:binary_id, Ecto.ULID] ->
         case field in Kaffy.ResourceSchema.primary_keys(schema) do
           true -> text_input(form, field, opts)
-          false -> text_or_assoc(conn, schema, form, field, opts)
+          false -> text_or_assoc(conn, schema, form, field, type, opts)
         end
 
       :string ->
@@ -351,7 +351,7 @@ defmodule Kaffy.ResourceForm do
     end
   end
 
-  defp text_or_assoc(conn, schema, form, field, opts) do
+  defp text_or_assoc(conn, schema, form, field, type, opts) do
     actual_assoc =
       Enum.filter(Kaffy.ResourceSchema.associations(schema), fn a ->
         Kaffy.ResourceSchema.association(schema, a).owner_key == field
@@ -376,12 +376,22 @@ defmodule Kaffy.ResourceForm do
 
             content_tag :div, class: "input-group" do
               [
-                number_input(form, field,
-                  class: "form-control",
-                  id: field,
-                  disabled: opts[:readonly],
-                  aria_describedby: field
-                ),
+                case type do
+                  :id ->
+                    number_input(form, field,
+                      class: "form-control",
+                      id: field,
+                      disabled: opts[:readonly],
+                      aria_describedby: field
+                    )
+                  _ ->
+                    text_input(form, field,
+                      class: "form-control",
+                      id: field,
+                      disabled: opts[:readonly],
+                      aria_describedby: field
+                    )
+                end,
                 if opts[:readonly] do
                   ""
                 else
@@ -443,7 +453,12 @@ defmodule Kaffy.ResourceForm do
         end
 
       false ->
-        number_input(form, field, opts)
+        case type do
+          :id ->
+            number_input(form, field, opts)
+          _ ->
+            text_input(form, field, opts)
+        end
     end
   end
 


### PR DESCRIPTION
Currently text_or_assoc assumes that it's dealing with an integer id field. This changes makes it also support binary_id / Ecto.ULID fields.