### PR TITLE
Fix deprecation warning in 1.17 for using map.field notation

### DIFF
--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -433,7 +433,7 @@ defmodule Kaffy.Utils do
   defp get_schemas(mods) do
     Enum.filter(mods, fn m ->
       functions = m.__info__(:functions)
-      Keyword.has_key?(functions, :__schema__) && Map.has_key?(m.__struct__, :__meta__)
+      Keyword.has_key?(functions, :__schema__) && Map.has_key?(m.__struct__(), :__meta__)
     end)
   end
 


### PR DESCRIPTION
Fixes a runtime warning that popped up in Elixir v1.17 onward