### PR TITLE
fix for #333 Models without primary key cause 500 bug Something isn't working

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -162,9 +162,10 @@ defmodule Kaffy.ResourceAdmin do
   """
   def ordering(resource) do
     schema = resource[:schema]
-    [order_key | _] = ResourceSchema.primary_keys(schema)
-
-    Utils.get_assigned_value_or_default(resource, :ordering, desc: order_key)
+    case ResourceSchema.primary_keys(schema) do
+      [order_key | _] -> Utils.get_assigned_value_or_default(resource, :ordering, desc: order_key)
+      [] -> Utils.get_assigned_value_or_default(resource, :ordering, desc: :id)
+    end
   end
 
   @doc """

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -2,7 +2,7 @@ defmodule Kaffy.ResourceSchema do
   @moduledoc false
 
   def primary_keys(schema) do
-    schema.__schema__(:primary_key)
+    schema.__schema__(:primary_key) || []
   end
 
   def excluded_fields(schema) do
@@ -99,7 +99,7 @@ defmodule Kaffy.ResourceSchema do
   end
 
   defp reorder_fields(fields_list, schema) do
-    [_id, first_field | _fields] = schema.__schema__(:fields)
+    [first_field | _fields] = schema.__schema__(:fields) -- [:id]
 
     # this is a "nice" feature to re-order the default fields to put the specified fields at the top/bottom of the form
     fields_list


### PR DESCRIPTION
this should fix #333 by supplying a default :id if there is no primary key else we used the supplied key, this allows pivot tables to be used with a virtual :id field